### PR TITLE
feat: Implement pagination and sorting for list views

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -1,29 +1,49 @@
-//src/components/DataTable.tsx
 import React from 'react';
+import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 
-interface Column<T> {
-  key: string;
-  header: string;
-  render?: (item: T) => React.ReactNode;
+// 1. Define/Update Props
+export interface ColumnDef<T> {
+  key: keyof T | string; // Accessor key for the data
+  header: string;        // Column header text
+  render?: (item: T) => React.ReactNode; // Custom render function
+  sortable?: boolean;     // Is the column sortable?
 }
 
 interface DataTableProps<T> {
   data: T[];
-  columns: Column<T>[];
+  columns: ColumnDef<T>[];
   isLoading?: boolean;
+  // Pagination Props
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  itemsPerPage?: number; // Optional
+  totalItems?: number;   // Optional
+  // Sorting Props
+  sortColumn: string | null;
+  sortOrder: 'asc' | 'desc' | null;
+  onSort: (columnKey: string) => void;
 }
 
 const DataTable = <T extends Record<string, any>>({
   data,
   columns,
   isLoading = false,
+  currentPage,
+  totalPages,
+  onPageChange,
+  itemsPerPage, // Not used in rendering logic directly, but available if needed
+  totalItems,   // Not used in rendering logic directly, but available if needed
+  sortColumn,
+  sortOrder,
+  onSort,
 }: DataTableProps<T>) => {
   if (isLoading) {
     return (
       <div className="w-full flex justify-center items-center py-12">
         <div className="animate-pulse flex flex-col w-full">
           <div className="h-10 bg-gray-200 rounded mb-4"></div>
-          {[...Array(5)].map((_, i) => (
+          {[...Array(itemsPerPage || 5)].map((_, i) => ( // Use itemsPerPage for skeleton
             <div key={i} className="h-16 bg-gray-100 rounded mb-2"></div>
           ))}
         </div>
@@ -31,7 +51,7 @@ const DataTable = <T extends Record<string, any>>({
     );
   }
 
-  if (data.length === 0) {
+  if (data.length === 0 && !isLoading) {
     return (
       <div className="bg-white rounded-lg shadow-sm p-6 text-center">
         <p className="text-gray-500">No data available</p>
@@ -40,32 +60,125 @@ const DataTable = <T extends Record<string, any>>({
   }
 
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-full bg-white rounded-lg shadow-sm">
-        <thead>
-          <tr className="bg-gray-50 border-b border-gray-200">
-            {columns.map((column) => (
-              <th
-                key={column.key}
-                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
-              >
-                {column.header}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200">
-          {data.map((item, index) => (
-            <tr key={index} className="hover:bg-gray-50 transition-colors">
+    <div className="flex flex-col">
+      <div className="overflow-x-auto">
+        <table className="min-w-full bg-white rounded-lg shadow-sm">
+          <thead>
+            <tr className="bg-gray-50 border-b border-gray-200">
               {columns.map((column) => (
-                <td key={column.key} className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
-                  {column.render ? column.render(item) : item[column.key]}
-                </td>
+                <th
+                  key={column.key as string}
+                  className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  {column.sortable ? (
+                    <button
+                      onClick={() => onSort(column.key as string)}
+                      className="flex items-center space-x-1 hover:text-gray-700 focus:outline-none"
+                    >
+                      <span>{column.header}</span>
+                      {sortColumn === column.key && (
+                        sortOrder === 'asc' ? <ChevronUp size={14} /> : <ChevronDown size={14} />
+                      )}
+                    </button>
+                  ) : (
+                    column.header
+                  )}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {data.map((item, index) => (
+              <tr key={item.id || index} className="hover:bg-gray-50 transition-colors"> {/* Use item.id if available */}
+                {columns.map((column) => (
+                  <td key={column.key as string} className="px-6 py-4 whitespace-nowrap text-sm text-gray-700">
+                    {column.render ? column.render(item) : item[column.key as keyof T]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* 3. Implement Pagination UI and Logic */}
+      {totalPages > 0 && (
+        <div className="py-4 flex items-center justify-between bg-white px-4 rounded-b-lg shadow-sm border-t border-gray-200">
+          <div className="flex-1 flex justify-between sm:hidden">
+            <button
+              onClick={() => onPageChange(currentPage - 1)}
+              disabled={currentPage <= 1}
+              className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => onPageChange(currentPage + 1)}
+              disabled={currentPage >= totalPages}
+              className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50"
+            >
+              Next
+            </button>
+          </div>
+          <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm text-gray-700">
+                Page <span className="font-medium">{currentPage}</span> of <span className="font-medium">{totalPages}</span>
+                {totalItems && itemsPerPage && (
+                     <span className="ml-2">
+                        (Showing {Math.min((currentPage - 1) * itemsPerPage + 1, totalItems)}
+                        - {Math.min(currentPage * itemsPerPage, totalItems)} of {totalItems} items)
+                     </span>
+                )}
+              </p>
+            </div>
+            <div>
+              <nav className="relative z-0 inline-flex rounded-md shadow-sm -space-x-px" aria-label="Pagination">
+                <button
+                  onClick={() => onPageChange(currentPage - 1)}
+                  disabled={currentPage <= 1}
+                  className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  <span className="sr-only">Previous</span>
+                  <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+                </button>
+                {/* Basic Page Numbers - could be expanded */}
+                {Array.from({ length: Math.min(5, totalPages) }, (_, i) => {
+                    let pageNum = i + 1;
+                    if (totalPages > 5 && currentPage > 3) {
+                        pageNum = currentPage - 2 + i;
+                        if (pageNum > totalPages - 2 && totalPages > 5) pageNum = totalPages - 4 + i; // ensure last 5 pages are shown
+                    }
+                    if (pageNum < 1 || pageNum > totalPages) return null; // Don't render invalid page numbers
+
+                    return (
+                         <button
+                            key={pageNum}
+                            onClick={() => onPageChange(pageNum)}
+                            aria-current={currentPage === pageNum ? 'page' : undefined}
+                            className={`relative inline-flex items-center px-4 py-2 border text-sm font-medium
+                                ${currentPage === pageNum 
+                                    ? 'z-10 bg-blue-50 border-blue-500 text-blue-600' 
+                                    : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+                                }`}
+                         >
+                            {pageNum}
+                         </button>
+                    );
+                })}
+                <button
+                  onClick={() => onPageChange(currentPage + 1)}
+                  disabled={currentPage >= totalPages}
+                  className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50"
+                >
+                  <span className="sr-only">Next</span>
+                  <ChevronRight className="h-5 w-5" aria-hidden="true" />
+                </button>
+              </nav>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -4,22 +4,24 @@ import { useOutletContext } from 'react-router-dom';
 import {
   fetchLinks,
   fetchSoftware,
-  // fetchVersionsForSoftware, // No longer needed directly in this view if AdminLinkEntryForm handles it
-  deleteAdminLink // Import delete function
+  fetchVersionsForSoftware, // For version dropdown
+  deleteAdminLink,
+  PaginatedLinksResponse // Import PaginatedLinksResponse
 } from '../services/api';
 import {
   Link as LinkType,
-  Software
-  // AddLinkPayloadFlexible, EditLinkPayloadFlexible are used by AdminLinkEntryForm
+  Software,
+  SoftwareVersion // For version dropdown
 } from '../types';
+import DataTable, { ColumnDef } from '../components/DataTable'; // Import DataTable and ColumnDef
 import FilterTabs from '../components/FilterTabs';
-import LinkCard from '../components/LinkCard';
-import LoadingState from '../components/LoadingState';
+// Removed LinkCard as we are moving to DataTable
+// import LoadingState from '../components/LoadingState'; // DataTable has its own
 import ErrorState from '../components/ErrorState';
 import { useAuth } from '../context/AuthContext';
-import AdminLinkEntryForm from '../components/admin/AdminLinkEntryForm'; // Ensure this is the updated form
-import ConfirmationModal from '../components/shared/ConfirmationModal'; // For delete confirmation
-import { PlusCircle, Edit3, Trash2 } from 'lucide-react'; // Icons for buttons
+import AdminLinkEntryForm from '../components/admin/AdminLinkEntryForm';
+import ConfirmationModal from '../components/shared/ConfirmationModal';
+import { PlusCircle, Edit3, Trash2, ExternalLink } from 'lucide-react';
 
 interface OutletContextType {
   searchTerm: string;
@@ -29,73 +31,144 @@ const LinksView: React.FC = () => {
   const { searchTerm } = useOutletContext<OutletContextType>();
   const { isAuthenticated, role } = useAuth();
 
+  // Data and Table State
   const [links, setLinks] = useState<LinkType[]>([]);
   const [softwareList, setSoftwareList] = useState<Software[]>([]);
-  const [selectedSoftwareId, setSelectedSoftwareId] = useState<number | null>(null);
+  const [versionList, setVersionList] = useState<SoftwareVersion[]>([]); // For version dropdown
+
+  // Filter State
+  const [activeSoftwareId, setActiveSoftwareId] = useState<number | null>(null);
+  const [activeVersionId, setActiveVersionId] = useState<number | null>(null);
   
+  // Pagination State
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(10);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalLinks, setTotalLinks] = useState<number>(0);
+
+  // Sorting State
+  const [sortBy, setSortBy] = useState<string>('title'); // Default sort column
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+
+  // Loading and Error State
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // State for managing the Add/Edit form visibility and data
+  // UI State for Forms and Modals
   const [showAddOrEditForm, setShowAddOrEditForm] = useState(false);
   const [editingLink, setEditingLink] = useState<LinkType | null>(null);
-
-  // State for delete confirmation
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [linkToDelete, setLinkToDelete] = useState<LinkType | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
 
   const loadLinks = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
-      const linksData = await fetchLinks(
-        selectedSoftwareId === null ? undefined : selectedSoftwareId
+      const response: PaginatedLinksResponse = await fetchLinks(
+        activeSoftwareId || undefined,
+        activeVersionId || undefined,
+        currentPage,
+        itemsPerPage,
+        sortBy,
+        sortOrder
       );
-      setLinks(linksData);
+      setLinks(response.links);
+      setTotalPages(response.total_pages);
+      setTotalLinks(response.total_links);
+      setCurrentPage(response.page);
+      setItemsPerPage(response.per_page);
     } catch (err: any) {
       setError(err.message || 'Failed to fetch links.');
       console.error("Error fetching links:", err);
     } finally {
       setIsLoading(false);
     }
-  }, [selectedSoftwareId]);
+  }, [activeSoftwareId, activeVersionId, currentPage, itemsPerPage, sortBy, sortOrder]);
 
   useEffect(() => {
-    const loadSoftwareForFilters = async () => {
+    const loadSoftwareAndInitialLinks = async () => {
+      setIsLoading(true);
       try {
         const softwareData = await fetchSoftware();
         setSoftwareList(softwareData);
+        // Initial load of links can happen here or rely on the second useEffect
       } catch (err) {
         console.error("Failed to load software for filters", err);
-        // Optionally set an error state for software loading if critical
+        setError("Failed to load software filters. Links may not display correctly.");
       }
+      // No finally setIsLoading(false) here, let loadLinks handle it
     };
-    loadSoftwareForFilters();
+    loadSoftwareAndInitialLinks();
   }, []);
-
+  
   useEffect(() => {
     loadLinks();
-  }, [loadLinks]); // selectedSoftwareId is a dependency of loadLinks
+  }, [loadLinks]); // Dependencies are now managed by useCallback for loadLinks
 
-  const handleFilterChange = (softwareId: number | null) => {
-    setSelectedSoftwareId(softwareId);
+  useEffect(() => {
+    // Fetch versions when activeSoftwareId changes
+    if (activeSoftwareId) {
+      const loadVersions = async () => {
+        try {
+          const versionsData = await fetchVersionsForSoftware(activeSoftwareId);
+          setVersionList(versionsData);
+        } catch (err) {
+          console.error("Failed to load versions for software:", activeSoftwareId, err);
+          setVersionList([]); // Clear previous versions on error
+        }
+      };
+      loadVersions();
+    } else {
+      setVersionList([]); // Clear versions if no software is selected
+    }
+  }, [activeSoftwareId]);
+
+
+  const handleSoftwareFilterChange = (softwareId: number | null) => {
+    setActiveSoftwareId(softwareId);
+    setActiveVersionId(null); // Reset version when software changes
+    setCurrentPage(1);
   };
 
-  const handleOperationSuccess = () => { // Called after successful Add or Update
+  const handleVersionFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const versionId = event.target.value ? parseInt(event.target.value, 10) : null;
+    setActiveVersionId(versionId);
+    setCurrentPage(1);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setCurrentPage(newPage);
+  };
+
+  const handleSort = (columnKey: string) => {
+    if (sortBy === columnKey) {
+      setSortOrder(prevOrder => (prevOrder === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(columnKey);
+      setSortOrder('asc');
+    }
+    setCurrentPage(1);
+  };
+  
+  const handleOperationSuccess = (message: string) => {
     setShowAddOrEditForm(false);
     setEditingLink(null);
-    loadLinks(); // Refresh the list
+    setFeedbackMessage(message);
+    loadLinks(); // Refresh
   };
   
   const openAddForm = () => {
-    setEditingLink(null); // Ensure not in edit mode
+    setEditingLink(null);
     setShowAddOrEditForm(true);
+    setFeedbackMessage(null);
   };
 
   const openEditForm = (link: LinkType) => {
     setEditingLink(link);
     setShowAddOrEditForm(true);
+    setFeedbackMessage(null);
   };
 
   const closeAdminForm = () => {
@@ -106,6 +179,7 @@ const LinksView: React.FC = () => {
   const openDeleteConfirm = (link: LinkType) => {
     setLinkToDelete(link);
     setShowDeleteConfirm(true);
+    setFeedbackMessage(null);
   };
 
   const closeDeleteConfirm = () => {
@@ -116,43 +190,74 @@ const LinksView: React.FC = () => {
   const handleDeleteConfirm = async () => {
     if (!linkToDelete) return;
     setIsDeleting(true);
-    setError(null); // Clear previous general errors
+    setError(null);
     try {
       await deleteAdminLink(linkToDelete.id);
+      setFeedbackMessage(`Link "${linkToDelete.title}" deleted successfully.`);
       closeDeleteConfirm();
-      loadLinks(); // Refresh list after delete
+      if (links.length === 1 && currentPage > 1) {
+        setCurrentPage(currentPage - 1);
+      } else {
+        loadLinks();
+      }
     } catch (err: any) {
-      // Set error specific to delete operation if needed, or use general error state
       setError(err.response?.data?.msg || err.message || "Failed to delete link.");
-      console.error("Delete error:", err);
-      closeDeleteConfirm(); // Close modal even on error
+      closeDeleteConfirm();
     } finally {
       setIsDeleting(false);
     }
   };
 
-  const filteredLinks = useMemo(() => {
-    if (!searchTerm) {
-      return links;
-    }
+  // Client-side search on the currently fetched page of links
+  const filteredLinksBySearch = useMemo(() => {
+    if (!searchTerm) return links;
     const lowerSearchTerm = searchTerm.toLowerCase();
     return links.filter(link =>
       link.title.toLowerCase().includes(lowerSearchTerm) ||
       (link.description || '').toLowerCase().includes(lowerSearchTerm) ||
       (link.software_name || '').toLowerCase().includes(lowerSearchTerm) ||
-      (link.version_number || '').toLowerCase().includes(lowerSearchTerm) // Link version_number is now mandatory string
+      (link.version_name || '').toLowerCase().includes(lowerSearchTerm)
     );
   }, [links, searchTerm]);
 
-  const handleRetryFetch = () => {
-      loadLinks();
-      if(softwareList.length === 0) {
-        const loadSoftwareForFilters = async () => {
-             try { const sw = await fetchSoftware(); setSoftwareList(sw); } catch (e) { console.error(e); }
-        };
-        loadSoftwareForFilters();
-      }
-  }
+  const columns: ColumnDef<LinkType>[] = [
+    { key: 'title', header: 'Title', sortable: true },
+    { key: 'software_name', header: 'Software', sortable: true },
+    { key: 'version_name', header: 'Version', sortable: true },
+    { key: 'description', header: 'Description', render: (link: LinkType) => (
+        <span className="text-sm text-gray-600 block max-w-xs truncate" title={link.description || ''}>
+          {link.description || '-'}
+        </span>
+      ) 
+    },
+    { 
+      key: 'url', 
+      header: 'URL', 
+      render: (link: LinkType) => (
+        <a
+          href={link.url}
+          target={link.is_external_link || !link.url?.startsWith('/') ? "_blank" : "_self"}
+          rel="noopener noreferrer"
+          className="flex items-center text-blue-600 hover:text-blue-800"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {link.url.length > 50 ? `${link.url.substring(0, 50)}...` : link.url}
+          {(link.is_external_link || !link.url?.startsWith('/')) && <ExternalLink size={14} className="ml-1 flex-shrink-0" />}
+        </a>
+      ) 
+    },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (link) => link.created_at ? new Date(link.created_at).toLocaleDateString() : '-' },
+    ...(isAuthenticated && role === 'admin' ? [{
+      key: 'actions' as keyof LinkType | 'actions',
+      header: 'Actions',
+      render: (link: LinkType) => (
+        <div className="flex space-x-2">
+          <button onClick={(e) => { e.stopPropagation(); openEditForm(link);}} className="p-1 text-blue-600 hover:text-blue-800" title="Edit Link"><Edit3 size={16} /></button>
+          <button onClick={(e) => { e.stopPropagation(); openDeleteConfirm(link);}} className="p-1 text-red-600 hover:text-red-800" title="Delete Link"><Trash2 size={16} /></button>
+        </div>
+      ),
+    }] : [])
+  ];
 
   return (
     <div className="space-y-6">
@@ -163,7 +268,7 @@ const LinksView: React.FC = () => {
         </div>
         {isAuthenticated && role === 'admin' && (
           <button
-             onClick={showAddOrEditForm && !editingLink ? closeAdminForm : openAddForm} // Toggle Add form or open it
+             onClick={showAddOrEditForm && !editingLink ? closeAdminForm : openAddForm}
             className="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
           >
             <PlusCircle size={18} className="mr-2" />
@@ -172,74 +277,69 @@ const LinksView: React.FC = () => {
         )}
       </div>
 
-      {/* Admin Form for Adding or Editing a Link */}
+      {feedbackMessage && <div className="p-3 my-2 bg-green-100 text-green-700 rounded text-sm">{feedbackMessage}</div>}
+
       {showAddOrEditForm && isAuthenticated && role === 'admin' && (
         <div className="my-6 p-4 bg-gray-50 rounded-lg shadow">
           <AdminLinkEntryForm
-            linkToEdit={editingLink} // Pass null for "Add" mode, or the link object for "Edit"
-            onLinkAdded={handleOperationSuccess}
-            onLinkUpdated={handleOperationSuccess}
+            linkToEdit={editingLink}
+            onLinkAdded={() => handleOperationSuccess('Link added successfully.')}
+            onLinkUpdated={() => handleOperationSuccess('Link updated successfully.')}
             onCancelEdit={closeAdminForm}
           />
         </div>
       )}
 
-      {/* Filters */}
-      {softwareList.length > 0 && (!error || links.length > 0) && ( // Show filters if data or no critical error
-        <FilterTabs
-          software={softwareList}
-          selectedSoftwareId={selectedSoftwareId}
-          onSelectFilter={handleFilterChange}
-        />
-      )}
+      <div className="flex space-x-4 items-center">
+        {softwareList.length > 0 && (
+          <FilterTabs
+            software={softwareList}
+            selectedSoftwareId={activeSoftwareId}
+            onSelectFilter={handleSoftwareFilterChange}
+          />
+        )}
+        {activeSoftwareId && versionList.length > 0 && (
+          <div className="relative">
+            <select
+              value={activeVersionId || ''}
+              onChange={handleVersionFilterChange}
+              className="block appearance-none w-full bg-white border border-gray-300 text-gray-700 py-2 px-4 pr-8 rounded-md leading-tight focus:outline-none focus:bg-white focus:border-blue-500 shadow-sm text-sm"
+            >
+              <option value="">All Versions for {softwareList.find(s=>s.id === activeSoftwareId)?.name || 'Selected Software'}</option>
+              {versionList.map(version => (
+                <option key={version.id} value={version.id}>
+                  {version.version_number}
+                </option>
+              ))}
+            </select>
+             <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
+                <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
+            </div>
+          </div>
+        )}
+      </div>
 
-      {/* Links Display */}
-      {isLoading ? (
-        <LoadingState />
-      ) : error && links.length === 0 ? ( // Show full error state only if no data could be loaded
-        <ErrorState message={error} onRetry={handleRetryFetch} />
+      {error && links.length === 0 && !isLoading ? (
+        <ErrorState message={error} onRetry={loadLinks} />
       ) : (
         <>
-          {error && <div className="p-3 my-2 bg-red-100 text-red-700 rounded text-sm">{error}</div>} {/* Inline error */}
-          {filteredLinks.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
-              {filteredLinks.map((link) => (
-                <div key={link.id} className="relative group bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md transition-shadow duration-200">
-                  <LinkCard link={link} />
-                  {isAuthenticated && role === 'admin' && (
-                    <div className="absolute top-2 right-2 flex space-x-1 opacity-0 group-hover:opacity-100 transition-opacity bg-white p-1 rounded-md shadow-lg border border-gray-100 z-10">
-                      <button
-                        onClick={() => openEditForm(link)}
-                        className="p-1.5 text-blue-600 hover:text-blue-800 rounded-full hover:bg-blue-50"
-                        title="Edit Link"
-                      >
-                        <Edit3 size={16} />
-                      </button>
-                      <button
-                        onClick={() => openDeleteConfirm(link)}
-                        className="p-1.5 text-red-600 hover:text-red-800 rounded-full hover:bg-red-50"
-                        title="Delete Link"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          ) : (
-             <div className="col-span-full text-center py-12 bg-white rounded-lg shadow-sm border">
-              <p className="text-gray-500">
-                No links found{selectedSoftwareId ? ` for ${softwareList.find(s=>s.id === selectedSoftwareId)?.name || 'selected software'}` : ''}
-                {searchTerm && ` matching "${searchTerm}"`}.
-                {isAuthenticated && role === 'admin' && !showAddOrEditForm && " You can add one."}
-              </p>
-            </div>
-          )}
+          {error && <div className="p-3 my-2 bg-red-100 text-red-700 rounded text-sm">{error}</div>}
+          <DataTable
+            columns={columns}
+            data={filteredLinksBySearch} // Use client-side search results
+            isLoading={isLoading}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+            itemsPerPage={itemsPerPage}
+            totalItems={totalLinks}
+            sortColumn={sortBy}
+            sortOrder={sortOrder}
+            onSort={handleSort}
+          />
         </>
       )}
 
-      {/* Delete Confirmation Modal */}
       {showDeleteConfirm && linkToDelete && (
         <ConfirmationModal
           isOpen={showDeleteConfirm}

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -1,49 +1,64 @@
 // src/views/MiscView.tsx
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '../context/AuthContext';
 import {
-  fetchMiscCategories, // addAdminMiscCategory is now handled by the form
-  fetchMiscFiles, // For editing via AdminMiscCategoryForm
+  fetchMiscCategories,
+  fetchMiscFiles,
   deleteAdminMiscCategory,
-  deleteAdminMiscFile // Added for file deletion functionality
+  deleteAdminMiscFile,
+  PaginatedMiscFilesResponse // Import PaginatedMiscFilesResponse
 } from '../services/api';
-import { MiscCategory, MiscFile } from '../types'; // AddCategoryPayload is used by AdminMiscCategoryForm
-import LoadingState from '../components/LoadingState';
+import { MiscCategory, MiscFile } from '../types';
+import DataTable, { ColumnDef } from '../components/DataTable'; // Import DataTable and ColumnDef
+// import LoadingState from '../components/LoadingState'; // DataTable has its own
 import ErrorState from '../components/ErrorState';
-import AdminUploadToMiscForm from '../components/admin/AdminUploadToMiscForm'; // For uploading files
-import AdminMiscCategoryForm from '../components/admin/AdminMiscCategoryForm'; // For Add/Edit Category
+import AdminUploadToMiscForm from '../components/admin/AdminUploadToMiscForm';
+import AdminMiscCategoryForm from '../components/admin/AdminMiscCategoryForm';
 import ConfirmationModal from '../components/shared/ConfirmationModal';
-import { Download, FileText, CalendarDays, ChevronDown, ChevronUp, PlusCircle, Edit3, Trash2 } from 'lucide-react';
+import { Download, FileText, CalendarDays, PlusCircle, Edit3, Trash2 } from 'lucide-react'; // Keep existing icons
 
 const API_BASE_URL = 'http://127.0.0.1:5000'; // Consider importing from a central config
 
 const MiscView: React.FC = () => {
   const { isAuthenticated, role } = useAuth();
+
+  // Categories State
   const [categories, setCategories] = useState<MiscCategory[]>([]);
   const [isLoadingCategories, setIsLoadingCategories] = useState(true);
   const [errorCategories, setErrorCategories] = useState<string | null>(null);
+  
+  // Misc Files State (Data and Table Controls)
+  const [miscFiles, setMiscFiles] = useState<MiscFile[]>([]);
+  const [isLoadingFiles, setIsLoadingFiles] = useState(true); // Single loading state for files table
+  const [errorFiles, setErrorFiles] = useState<string | null>(null);
+  
+  // Filter State
+  const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
 
-  // State for showing/hiding the Add/Edit Category Form and the category being edited
+  // Pagination State
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(10);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalMiscFiles, setTotalMiscFiles] = useState<number>(0);
+
+  // Sorting State
+  const [sortBy, setSortBy] = useState<string>('user_provided_title'); // Default sort column
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+
+  // UI State for Forms and Modals
   const [showCategoryForm, setShowCategoryForm] = useState(false);
   const [editingCategory, setEditingCategory] = useState<MiscCategory | null>(null);
-
-  // State for file uploads and display
-  const [categoryFiles, setCategoryFiles] = useState<Record<number, MiscFile[]>>({});
-  const [isLoadingFiles, setIsLoadingFiles] = useState<Record<number, boolean>>({});
-  const [expandedCategories, setExpandedCategories] = useState<Record<number, boolean>>({});
   const [showGeneralUploadForm, setShowGeneralUploadForm] = useState(false);
-
-  // State for Delete Category Confirmation
   const [categoryToDelete, setCategoryToDelete] = useState<MiscCategory | null>(null);
   const [showDeleteCategoryConfirm, setShowDeleteCategoryConfirm] = useState(false);
   const [isDeletingCategory, setIsDeletingCategory] = useState(false);
   const [deleteCategoryError, setDeleteCategoryError] = useState<string | null>(null);
-  
-  // State for Individual File Deletion
   const [fileToDelete, setFileToDelete] = useState<MiscFile | null>(null);
   const [showDeleteFileConfirm, setShowDeleteFileConfirm] = useState(false);
   const [isDeletingFile, setIsDeletingFile] = useState(false);
   const [deleteFileError, setDeleteFileError] = useState<string | null>(null);
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+
 
   const loadMiscCategories = useCallback(async () => {
     setIsLoadingCategories(true);
@@ -63,131 +78,133 @@ const MiscView: React.FC = () => {
     loadMiscCategories();
   }, [loadMiscCategories]);
 
-  const fetchFilesForCategory = useCallback(async (categoryId: number, forceRefresh = false) => {
-    if (!forceRefresh && categoryFiles[categoryId] && !isLoadingFiles[categoryId]) {
-      // Files already loaded and not forcing refresh, do nothing
-      return;
-    }
-    
-    setIsLoadingFiles(prev => ({ ...prev, [categoryId]: true }));
+  const loadMiscFiles = useCallback(async () => {
+    setIsLoadingFiles(true);
+    setErrorFiles(null);
     try {
-      const files = await fetchMiscFiles(categoryId);
-      setCategoryFiles(prev => ({ ...prev, [categoryId]: files }));
-    } catch (err) {
-      console.error(`Failed to load files for category ${categoryId}`, err);
+      const response: PaginatedMiscFilesResponse = await fetchMiscFiles(
+        activeCategoryId || undefined,
+        currentPage,
+        itemsPerPage,
+        sortBy,
+        sortOrder
+      );
+      setMiscFiles(response.misc_files);
+      setTotalPages(response.total_pages);
+      setTotalMiscFiles(response.total_misc_files);
+      setCurrentPage(response.page);
+      setItemsPerPage(response.per_page);
+    } catch (err: any) {
+      setErrorFiles(err.message || 'Failed to fetch miscellaneous files.');
+      console.error("Error fetching misc files:", err);
     } finally {
-      setIsLoadingFiles(prev => ({ ...prev, [categoryId]: false }));
+      setIsLoadingFiles(false);
     }
-  }, [categoryFiles, isLoadingFiles]);
+  }, [activeCategoryId, currentPage, itemsPerPage, sortBy, sortOrder]);
 
-  const toggleCategoryFiles = (categoryId: number) => {
-    const isCurrentlyExpanded = !!expandedCategories[categoryId];
-    setExpandedCategories(prev => ({ ...prev, [categoryId]: !isCurrentlyExpanded }));
-    if (!isCurrentlyExpanded) {
-      fetchFilesForCategory(categoryId);
+  useEffect(() => {
+    loadMiscFiles();
+  }, [loadMiscFiles]);
+
+
+  const handleCategoryFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const categoryId = event.target.value ? parseInt(event.target.value, 10) : null;
+    setActiveCategoryId(categoryId);
+    setCurrentPage(1); // Reset to first page
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setCurrentPage(newPage);
+  };
+
+  const handleSort = (columnKey: string) => {
+    if (sortBy === columnKey) {
+      setSortOrder(prevOrder => (prevOrder === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(columnKey);
+      setSortOrder('asc');
     }
+    setCurrentPage(1);
   };
 
   const handleMiscFileUploadSuccess = (uploadedFile: MiscFile) => {
-    fetchFilesForCategory(uploadedFile.misc_category_id, true); // Force refresh after upload
-    setShowGeneralUploadForm(false); // Close general form if it was open
-    setExpandedCategories(prev => ({...prev, [uploadedFile.misc_category_id]: true})); // Ensure category is open
+    setShowGeneralUploadForm(false);
+    setFeedbackMessage(`File "${uploadedFile.user_provided_title || uploadedFile.original_filename}" uploaded successfully.`);
+    // If the upload was for the currently active category (or if no category is active), refresh
+    if (activeCategoryId === null || activeCategoryId === uploadedFile.misc_category_id) {
+      loadMiscFiles();
+    }
   };
 
-  const formatDate = (dateString: string | null): string => {
+  const formatDate = (dateString: string | null | undefined): string => {
     if (!dateString) return 'N/A';
     try {
       return new Date(dateString).toLocaleDateString('en-US', {
         year: 'numeric', month: 'short', day: 'numeric',
         hour: '2-digit', minute: '2-digit'
       });
-    } catch (e) {
-      return "Invalid Date";
-    }
+    } catch (e) { return "Invalid Date"; }
+  };
+  
+  const formatFileSize = (bytes: number | null | undefined): string => {
+    if (bytes === null || typeof bytes === 'undefined') return 'N/A';
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  // --- Category Add/Edit/Delete Handlers ---
-  const handleOpenAddCategoryForm = () => {
-    setEditingCategory(null);
-    setShowCategoryForm(true);
-  };
 
-  const handleOpenEditCategoryForm = (category: MiscCategory) => {
-    setEditingCategory(category);
-    setShowCategoryForm(true);
-  };
-
-  const handleCloseCategoryForm = () => {
-    setEditingCategory(null);
-    setShowCategoryForm(false);
-  };
-
-  const handleCategoryOperationSuccess = () => {
+  // --- Category Add/Edit/Delete Handlers (mostly preserved) ---
+  const handleOpenAddCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(true); setFeedbackMessage(null); };
+  const handleOpenEditCategoryForm = (category: MiscCategory) => { setEditingCategory(category); setShowCategoryForm(true); setFeedbackMessage(null);};
+  const handleCloseCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(false); };
+  const handleCategoryOperationSuccess = (message: string) => {
     setShowCategoryForm(false);
     setEditingCategory(null);
-    loadMiscCategories(); // Refresh list
+    setFeedbackMessage(message);
+    loadMiscCategories(); 
   };
-
-  const handleOpenDeleteCategoryConfirm = (category: MiscCategory) => {
-    setCategoryToDelete(category);
-    setDeleteCategoryError(null);
-    setShowDeleteCategoryConfirm(true);
-  };
-
-  const handleCloseDeleteCategoryConfirm = () => {
-    setCategoryToDelete(null);
-    setShowDeleteCategoryConfirm(false);
-    setDeleteCategoryError(null);
-  };
-
+  const handleOpenDeleteCategoryConfirm = (category: MiscCategory) => { setCategoryToDelete(category); setDeleteCategoryError(null); setShowDeleteCategoryConfirm(true); setFeedbackMessage(null); };
+  const handleCloseDeleteCategoryConfirm = () => { setCategoryToDelete(null); setShowDeleteCategoryConfirm(false); setDeleteCategoryError(null);};
   const handleDeleteCategoryConfirm = async () => {
     if (!categoryToDelete) return;
-
-    // If a blocking error is already displayed, clicking "Delete" again might do nothing
-    // or we can prevent re-attempt if the specific error is present.
-    if (deleteCategoryError && deleteCategoryError.includes("Cannot delete category")) {
-      // Optionally, you could just close the modal here if the button text is "Cannot Delete"
-      // handleCloseDeleteCategoryConfirm();
-      return; // Prevent re-attempting delete if already known it can't be deleted
-    }
-
+    if (deleteCategoryError && deleteCategoryError.includes("Cannot delete category")) return;
     setIsDeletingCategory(true);
-    setDeleteCategoryError(null); // Clear for new attempt
+    setDeleteCategoryError(null);
     try {
       await deleteAdminMiscCategory(categoryToDelete.id);
+      setFeedbackMessage(`Category "${categoryToDelete.name}" deleted successfully.`);
       handleCloseDeleteCategoryConfirm();
       loadMiscCategories();
+      if (activeCategoryId === categoryToDelete.id) { // If deleted category was the active filter
+        setActiveCategoryId(null); // Reset filter, which will trigger loadMiscFiles
+      }
     } catch (err: any) {
       const errorMsg = err.response?.data?.msg || err.message || "Failed to delete category.";
       setDeleteCategoryError(errorMsg);
-      // The modal will now display this errorMsg. The user can then only "Cancel".
     } finally {
       setIsDeletingCategory(false);
     }
   };
 
-  // --- File Deletion Handlers ---
-  const handleOpenDeleteFileConfirm = (file: MiscFile) => {
-    setFileToDelete(file);
-    setDeleteFileError(null); // Clear previous errors
-    setShowDeleteFileConfirm(true);
-  };
-
-  const handleCloseDeleteFileConfirm = () => {
-    setFileToDelete(null);
-    setShowDeleteFileConfirm(false);
-    setDeleteFileError(null);
-  };
-
+  // --- File Deletion Handlers (mostly preserved) ---
+  const handleOpenDeleteFileConfirm = (file: MiscFile) => { setFileToDelete(file); setDeleteFileError(null); setShowDeleteFileConfirm(true); setFeedbackMessage(null);};
+  const handleCloseDeleteFileConfirm = () => { setFileToDelete(null); setShowDeleteFileConfirm(false); setDeleteFileError(null);};
   const handleDeleteFileConfirm = async () => {
     if (!fileToDelete) return;
     setIsDeletingFile(true);
     setDeleteFileError(null);
     try {
       await deleteAdminMiscFile(fileToDelete.id);
+      setFeedbackMessage(`File "${fileToDelete.user_provided_title || fileToDelete.original_filename}" deleted successfully.`);
       handleCloseDeleteFileConfirm();
-      // Refresh the file list for the specific category
-      fetchFilesForCategory(fileToDelete.misc_category_id, true); // Force refresh
+      if (miscFiles.length === 1 && currentPage > 1) {
+        setCurrentPage(currentPage - 1); // Will trigger loadMiscFiles
+      } else {
+        loadMiscFiles(); // Refresh current page
+      }
     } catch (err: any) {
       setDeleteFileError(err.response?.data?.msg || err.message || "Failed to delete file.");
     } finally {
@@ -195,200 +212,138 @@ const MiscView: React.FC = () => {
     }
   };
 
+  const columns: ColumnDef<MiscFile>[] = [
+    { key: 'user_provided_title', header: 'Title', sortable: true },
+    { key: 'original_filename', header: 'Original Filename', sortable: true },
+    { key: 'category_name', header: 'Category', sortable: true }, // Backend sorts by mc.name
+    { key: 'file_size', header: 'Size', sortable: true, render: (file) => formatFileSize(file.file_size) },
+    { key: 'created_at', header: 'Uploaded At', sortable: true, render: (file) => formatDate(file.created_at) },
+    {
+      key: 'file_path',
+      header: 'Link',
+      render: (file) => (
+        <a
+          href={`${API_BASE_URL}${file.file_path}`}
+          target="_blank" rel="noopener noreferrer"
+          className="flex items-center text-blue-600 hover:text-blue-800"
+          onClick={(e) => e.stopPropagation()}
+        >
+          Download <Download size={14} className="ml-1" />
+        </a>
+      )
+    },
+    ...(isAuthenticated && role === 'admin' ? [{
+      key: 'actions' as keyof MiscFile | 'actions',
+      header: 'Actions',
+      render: (file: MiscFile) => (
+        <div className="flex space-x-2">
+          {/* TODO: Implement Edit Misc File functionality if needed */}
+          {/* <button onClick={(e) => { e.stopPropagation(); alert('Edit TBD: '+file.id) }} className="p-1 text-blue-600 hover:text-blue-800" title="Edit File"><Edit3 size={16} /></button> */}
+          <button onClick={(e) => { e.stopPropagation(); handleOpenDeleteFileConfirm(file);}} className="p-1 text-red-600 hover:text-red-800" title="Delete File"><Trash2 size={16} /></button>
+        </div>
+      ),
+    }] : [])
+  ];
+
   return (
     <div className="space-y-8">
-      <div>
-        <h2 className="text-2xl font-bold text-gray-800 mb-2">Miscellaneous Content</h2>
-        <p className="text-gray-600">Browse categorized miscellaneous files and resources.</p>
+      <div className="flex justify-between items-start sm:items-center mb-6 flex-col sm:flex-row">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-800">Miscellaneous Files</h2>
+          <p className="text-gray-600 mt-1">Browse and download categorized miscellaneous files.</p>
+        </div>
+         {isAuthenticated && role === 'admin' && (
+            <div className="flex space-x-3 mt-4 sm:mt-0">
+                 <button
+                    onClick={() => {setShowCategoryForm(prev => !prev); setEditingCategory(null); setShowGeneralUploadForm(false); setFeedbackMessage(null);}}
+                    className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                >
+                    <PlusCircle size={18} className="mr-2" />
+                    {showCategoryForm && !editingCategory ? 'Cancel Add Category' : 'Add/Edit Category'}
+                </button>
+                 <button
+                    onClick={() => {setShowGeneralUploadForm(prev => !prev); setShowCategoryForm(false); setEditingCategory(null); setFeedbackMessage(null);}}
+                    className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+                >
+                    <PlusCircle size={18} className="mr-2" />
+                    {showGeneralUploadForm ? 'Cancel Upload' : 'Upload New File'}
+                </button>
+            </div>
+        )}
       </div>
 
-      {isAuthenticated && role === 'admin' && (
-        <section className="bg-white p-6 rounded-lg shadow-sm border border-gray-200 mb-8">
-          {!showCategoryForm && (
-            <button
-              onClick={handleOpenAddCategoryForm}
-              className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-            >
-              <PlusCircle size={18} className="mr-2" /> Add New Misc Category
-            </button>
-          )}
+      {feedbackMessage && <div className="p-3 my-2 bg-green-100 text-green-700 rounded text-sm">{feedbackMessage}</div>}
 
-          {showCategoryForm && (
-            <div className="my-4">
-              <AdminMiscCategoryForm
-                categoryToEdit={editingCategory}
-                onSuccess={handleCategoryOperationSuccess}
-                onCancel={handleCloseCategoryForm}
-              />
-            </div>
-          )}
+      {showCategoryForm && isAuthenticated && role === 'admin' && (
+        <div className="my-4 p-4 bg-gray-50 rounded-lg shadow">
+          <AdminMiscCategoryForm categoryToEdit={editingCategory} onSuccess={() => handleCategoryOperationSuccess(editingCategory ? "Category updated." : "Category added.")} onCancel={handleCloseCategoryForm} />
+        </div>
+      )}
+      {showGeneralUploadForm && isAuthenticated && role === 'admin' && (
+        <div className="my-4 p-4 bg-gray-50 rounded-lg shadow">
+          <AdminUploadToMiscForm onUploadSuccess={handleMiscFileUploadSuccess} />
+        </div>
+      )}
+      
+      {/* Category Filter Dropdown */}
+      <div className="my-4">
+        <label htmlFor="category-filter" className="block text-sm font-medium text-gray-700 mb-1">Filter by Category:</label>
+        <select
+          id="category-filter"
+          value={activeCategoryId === null ? '' : activeCategoryId}
+          onChange={handleCategoryFilterChange}
+          className="block w-full sm:w-1/3 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md shadow-sm"
+          disabled={isLoadingCategories}
+        >
+          <option value="">All Categories</option>
+          {categories.map(category => (
+            <option key={category.id} value={category.id}>{category.name}</option>
+          ))}
+        </select>
+        {isLoadingCategories && <p className="text-sm text-gray-500 mt-1">Loading categories...</p>}
+        {errorCategories && <p className="text-sm text-red-500 mt-1">{errorCategories}</p>}
+      </div>
 
-          <hr className="my-6" />
-          <button
-            onClick={() => setShowGeneralUploadForm(prev => !prev)}
-            className="mt-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
-          >
-            <PlusCircle size={18} className="mr-2" /> {showGeneralUploadForm ? 'Cancel General Upload' : 'Upload New Misc File (General)'}
-          </button>
-          {showGeneralUploadForm && (
-            <div className="mt-4">
-              <AdminUploadToMiscForm onUploadSuccess={handleMiscFileUploadSuccess} />
-            </div>
-          )}
-        </section>
+      {/* DataTable for Misc Files */}
+      {errorFiles && miscFiles.length === 0 && !isLoadingFiles ? (
+        <ErrorState message={errorFiles} onRetry={loadMiscFiles} />
+      ) : (
+        <>
+          {errorFiles && <div className="p-3 my-2 bg-red-100 text-red-700 rounded text-sm">{errorFiles}</div>}
+          <DataTable
+            columns={columns}
+            data={miscFiles} // DataTable expects the raw data
+            isLoading={isLoadingFiles}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+            itemsPerPage={itemsPerPage}
+            totalItems={totalMiscFiles}
+            sortColumn={sortBy}
+            sortOrder={sortOrder}
+            onSort={handleSort}
+          />
+        </>
       )}
 
-      <section className="space-y-6">
-        <h3 className="text-xl font-semibold text-gray-800">Categories</h3>
-        {isLoadingCategories ? (
-          <LoadingState message="Loading categories..." />
-        ) : errorCategories ? (
-          <ErrorState message={errorCategories} onRetry={loadMiscCategories} />
-        ) : categories.length > 0 ? (
-          categories.map(category => (
-            <div key={category.id} className="bg-white rounded-lg shadow-sm border border-gray-200">
-              <div className="p-4 sm:p-6 flex justify-between items-center group">
-                <div className="flex-1 cursor-pointer" onClick={() => toggleCategoryFiles(category.id)}>
-                  <h4 className="text-lg font-medium text-blue-700 hover:text-blue-800">{category.name}</h4>
-                  {category.description && <p className="text-sm text-gray-600">{category.description}</p>}
-                </div>
-                <div className="flex items-center space-x-2">
-                  {isAuthenticated && role === 'admin' && (
-                    <>
-                      <button
-                        onClick={() => handleOpenEditCategoryForm(category)}
-                        className="p-1.5 text-gray-500 hover:text-blue-600 rounded-full hover:bg-gray-100"
-                        title="Edit Category"
-                      >
-                        <Edit3 size={16} />
-                      </button>
-                      <button
-                        onClick={() => handleOpenDeleteCategoryConfirm(category)}
-                        className="p-1.5 text-gray-500 hover:text-red-600 rounded-full hover:bg-gray-100"
-                        title="Delete Category"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </>
-                  )}
-                  <button onClick={() => toggleCategoryFiles(category.id)} className="p-1.5 text-gray-500 hover:text-gray-700">
-                    {expandedCategories[category.id] ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-                  </button>
-                </div>
-              </div>
-              {expandedCategories[category.id] && (
-                <div className="border-t border-gray-200 p-4 sm:p-6">
-                  {isLoadingFiles[category.id] ? (<LoadingState message="Loading files..." />) :
-                    categoryFiles[category.id] && categoryFiles[category.id]!.length > 0 ? (
-                      <ul className="space-y-3">
-                        {categoryFiles[category.id]!.map(file => (
-                          <li key={file.id} className="pb-3 border-b border-gray-100 last:border-b-0 flex flex-col sm:flex-row justify-between items-start group relative">
-                            <div className="flex-1 flex items-start pr-4"> {/* Ensure text can wrap */}
-                              <FileText size={20} className="text-gray-500 mr-3 mt-1 flex-shrink-0" />
-                              <div className="flex-1">
-                                <p className="text-sm font-medium text-gray-800 break-all">{file.user_provided_title || file.original_filename}</p>
-                                {file.user_provided_description && <p className="text-xs text-gray-600 mt-0.5 break-words">{file.user_provided_description}</p>}
-                                <p className="text-xs text-gray-500 mt-1 flex items-center flex-wrap">
-                                  <CalendarDays size={12} className="mr-1" />
-                                  {formatDate(file.created_at ?? null)}
-                                  {file.file_size !== null && typeof file.file_size !== 'undefined' && (
-                                    <><span className="mx-1.5">|</span>{(file.file_size / (1024 * 1024)).toFixed(2)} MB</>
-                                  )}
-                                </p>
-                              </div>
-                            </div>
-                            <div className="mt-2 sm:mt-0 flex items-center space-x-2 flex-shrink-0">
-                              {/* Admin buttons for individual file management */}
-                              {isAuthenticated && role === 'admin' && (
-                                <>
-                                  <button 
-                                    onClick={() => { alert(`Edit file ${file.id} - TBD`); }}
-                                    className="p-1.5 text-blue-500 hover:text-blue-700 rounded-full hover:bg-blue-50"
-                                    title="Edit File Details"
-                                  >
-                                    <Edit3 size={14} />
-                                  </button>
-                                  <button 
-                                    onClick={() => handleOpenDeleteFileConfirm(file)}
-                                    className="p-1.5 text-red-500 hover:text-red-700 rounded-full hover:bg-red-50"
-                                    title="Delete File"
-                                  >
-                                    <Trash2 size={14} />
-                                  </button>
-                                </>
-                              )}
-                              <a
-                                href={`${API_BASE_URL}${file.file_path}`}
-                                target="_blank" rel="noopener noreferrer"
-                                className="inline-flex items-center px-3 py-1 border border-transparent text-xs font-medium rounded shadow-sm text-white bg-blue-600 hover:bg-blue-700"
-                              >
-                                <Download size={14} className="mr-1.5" /> Download
-                              </a>
-                            </div>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (<p className="text-sm text-gray-500">No files in this category yet.</p>)}
-                  {isAuthenticated && role === 'admin' && (
-                    <div className="mt-4 pt-4 border-t border-gray-100">
-                      <details>
-                        <summary className="text-sm font-medium text-blue-600 hover:underline cursor-pointer">Upload to "{category.name}"</summary>
-                        <div className="mt-3">
-                          <AdminUploadToMiscForm
-                            preselectedCategoryId={category.id}
-                            onUploadSuccess={handleMiscFileUploadSuccess}
-                          />
-                        </div>
-                      </details>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          ))
-        ) : (
-          <div className="bg-white p-6 rounded-lg shadow-sm border text-center">
-            <p className="text-gray-500">
-              No miscellaneous categories found.
-              {isAuthenticated && role === 'admin' && !showCategoryForm && " You can add one above."}
-            </p>
-          </div>
-        )}
-      </section>
-
-      {/* Delete Category Confirmation Modal */}
       {showDeleteCategoryConfirm && categoryToDelete && (
         <ConfirmationModal
           isOpen={showDeleteCategoryConfirm}
           title="Delete Category"
-          message={
-            deleteCategoryError ? 
-            <span className="text-red-600">{deleteCategoryError}</span> : // Display the error here
-            `Are you sure you want to delete the category "${categoryToDelete.name}"? This action cannot be undone.`
-          }
-          onConfirm={handleDeleteCategoryConfirm} // Always pass the handler
+          message={ deleteCategoryError ? <span className="text-red-600">{deleteCategoryError}</span> : `Are you sure you want to delete the category "${categoryToDelete.name}"? This action cannot be undone.`}
+          onConfirm={handleDeleteCategoryConfirm}
           onCancel={handleCloseDeleteCategoryConfirm}
           isConfirming={isDeletingCategory}
-          confirmButtonText={
-            // Change button text if deletion is known to be blocked by backend rule
-            deleteCategoryError && deleteCategoryError.includes("Cannot delete category") 
-              ? "Close" // Or "OK", as delete won't proceed
-              : "Delete"
-          }
+          confirmButtonText={deleteCategoryError && deleteCategoryError.includes("Cannot delete category") ? "Close" : "Delete"}
           confirmButtonVariant="danger"
         />
       )}
 
-      {/* Delete File Confirmation Modal */}
       {showDeleteFileConfirm && fileToDelete && (
         <ConfirmationModal
           isOpen={showDeleteFileConfirm}
           title="Delete File"
-          message={
-            deleteFileError ?
-            <span className="text-red-600">{deleteFileError}</span> :
-            `Are you sure you want to delete the file "${fileToDelete.user_provided_title || fileToDelete.original_filename}"? This action cannot be undone.`
-          }
+          message={deleteFileError ? <span className="text-red-600">{deleteFileError}</span> : `Are you sure you want to delete the file "${fileToDelete.user_provided_title || fileToDelete.original_filename}"?`}
           onConfirm={handleDeleteFileConfirm}
           onCancel={handleCloseDeleteFileConfirm}
           isConfirming={isDeletingFile}

--- a/frontend/src/views/SuperAdminDashboard.tsx
+++ b/frontend/src/views/SuperAdminDashboard.tsx
@@ -1,39 +1,57 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
-import { listUsers, updateUserRole, deactivateUser, activateUser, deleteUser, User, UpdateUserRolePayload } from '../services/api'; 
+import { listUsers, updateUserRole, deactivateUser, activateUser, deleteUser, User, UpdateUserRolePayload, PaginatedUsersResponse } from '../services/api';
+import DataTable, { ColumnDef } from '../components/DataTable'; // Import DataTable and ColumnDef
 
 const SuperAdminDashboard: React.FC = () => {
   const auth = useAuth();
-  const [users, setUsers] = useState<User[]>([]);
-  const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
-  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
 
-  // State for managing role editing
+  // State for data and table controls
+  const [users, setUsers] = useState<User[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState<number>(1);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(10); // Default items per page
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalUsers, setTotalUsers] = useState<number>(0);
+
+  // Sorting state
+  const [sortBy, setSortBy] = useState<string>('username'); // Default sort column
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc'); // Default sort order
+
+  // Feedback and UI state
+  const [feedback, setFeedback] = useState<{ type: 'success' | 'error'; message: string } | null>(null);
   const [editingRoleForUser, setEditingRoleForUser] = useState<number | null>(null);
   const [selectedRole, setSelectedRole] = useState<'user' | 'admin' | 'super_admin'>('user');
 
-  useEffect(() => {
+  const fetchUsers = useCallback(async () => {
     if (auth.isAuthenticated && auth.role === 'super_admin') {
-      fetchUsers();
+      setIsLoading(true);
+      setError(null);
+      // Feedback is not reset here to persist across page changes if it's a result of an action
+      try {
+        const response: PaginatedUsersResponse = await listUsers(currentPage, itemsPerPage, sortBy, sortOrder);
+        setUsers(response.users);
+        setTotalPages(response.total_pages);
+        setTotalUsers(response.total_users);
+        setCurrentPage(response.page); // Update current page from backend response
+        setItemsPerPage(response.per_page); // Update items per page from backend
+      } catch (err: any) {
+        setError(err.message || 'Failed to fetch users.');
+        setFeedback({ type: 'error', message: err.message || 'Failed to fetch users.' });
+      } finally {
+        setIsLoading(false);
+      }
     }
-  }, [auth.isAuthenticated, auth.role]);
+  }, [auth.isAuthenticated, auth.role, currentPage, itemsPerPage, sortBy, sortOrder]);
 
-  const fetchUsers = async () => {
-    setLoading(true);
-    setError(null);
-    setFeedback(null);
-    try {
-      const fetchedUsers = await listUsers();
-      setUsers(fetchedUsers);
-    } catch (err: any) {
-      setError(err.message || 'Failed to fetch users.');
-      setFeedback({ type: 'error', message: err.message || 'Failed to fetch users.' });
-    } finally {
-      setLoading(false);
-    }
-  };
+  useEffect(() => {
+    fetchUsers();
+  }, [fetchUsers]);
+
 
   if (!auth.isAuthenticated) {
     return <Navigate to="/login" replace />;
@@ -48,6 +66,20 @@ const SuperAdminDashboard: React.FC = () => {
     );
   }
 
+  const handlePageChange = (newPage: number) => {
+    setCurrentPage(newPage);
+  };
+
+  const handleSort = (columnKey: string) => {
+    if (sortBy === columnKey) {
+      setSortOrder(prevOrder => (prevOrder === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortBy(columnKey);
+      setSortOrder('asc');
+    }
+    setCurrentPage(1); // Reset to first page on sort change
+  };
+  
   const handleRoleChangeInitiate = (user: User) => {
     setEditingRoleForUser(user.id);
     setSelectedRole(user.role);
@@ -60,8 +92,9 @@ const SuperAdminDashboard: React.FC = () => {
     try {
       const payload: UpdateUserRolePayload = { new_role: selectedRole };
       const updatedUser = await updateUserRole(userId, payload);
-      setUsers(prevUsers => prevUsers.map(u => u.id === userId ? { ...u, role: updatedUser.role } : u));
+      // No direct UI update here, rely on fetchUsers to refresh data after action
       setFeedback({ type: 'success', message: `User ${updatedUser.username}'s role updated to ${updatedUser.role}.` });
+      fetchUsers(); // Re-fetch users to show updated data and reflect potential sort/page changes
     } catch (err: any) {
       setFeedback({ type: 'error', message: err.message || 'Failed to update role.' });
     } finally {
@@ -74,23 +107,21 @@ const SuperAdminDashboard: React.FC = () => {
       setFeedback(null);
       try {
         await deactivateUser(userId);
-        setUsers(prevUsers => prevUsers.map(u => u.id === userId ? { ...u, is_active: false } : u));
         setFeedback({ type: 'success', message: `User ${username} deactivated.` });
+        fetchUsers(); // Re-fetch
       } catch (err: any) {
         setFeedback({ type: 'error', message: err.message || `Failed to deactivate ${username}.` });
       }
     }
   };
 
-  // Placeholder for activateUser - will be implemented in api.ts later
   const handleActivate = async (userId: number, username: string) => {
      if (window.confirm(`Are you sure you want to activate user ${username}?`)) {
       setFeedback(null);
       try {
-        // Call the actual activateUser function from api.ts
         await activateUser(userId); 
-        setUsers(prevUsers => prevUsers.map(u => u.id === userId ? { ...u, is_active: true } : u));
         setFeedback({ type: 'success', message: `User ${username} activated.` });
+        fetchUsers(); // Re-fetch
       } catch (err: any) {
         setFeedback({ type: 'error', message: err.message || `Failed to activate ${username}.` });
       }
@@ -102,16 +133,119 @@ const SuperAdminDashboard: React.FC = () => {
       setFeedback(null);
       try {
         await deleteUser(userId);
-        setUsers(prevUsers => prevUsers.filter(u => u.id !== userId));
         setFeedback({ type: 'success', message: `User ${username} deleted.` });
+        // If on the last page and it becomes empty, go to previous page or first page
+        if (users.length === 1 && currentPage > 1) {
+            setCurrentPage(currentPage - 1); 
+        } else {
+            fetchUsers(); // Otherwise, just re-fetch
+        }
       } catch (err: any) {
         setFeedback({ type: 'error', message: err.message || `Failed to delete ${username}.` });
       }
     }
   };
-
-  if (loading) return <div className="container mx-auto p-4">Loading users...</div>;
-  if (error && users.length === 0) return <div className="container mx-auto p-4 text-red-500">Error: {error}</div>;
+  
+  const columns: ColumnDef<User>[] = [
+    { key: 'username', header: 'Username', sortable: true },
+    { key: 'email', header: 'Email', sortable: true, render: (user) => user.email || 'N/A' },
+    { 
+      key: 'role', 
+      header: 'Role', 
+      sortable: true,
+      render: (user) => {
+        if (editingRoleForUser === user.id) {
+          return (
+            <div className="flex items-center space-x-2">
+              <select
+                value={selectedRole}
+                onChange={(e) => setSelectedRole(e.target.value as 'user' | 'admin' | 'super_admin')}
+                className="block w-auto pl-3 pr-10 py-1 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
+                disabled={auth.username === user.username && users.filter(u => u.role === 'super_admin').length <= 1 && selectedRole !== 'super_admin'}
+                onClick={(e) => e.stopPropagation()} // Prevent row click if any
+              >
+                <option value="user">User</option>
+                <option value="admin">Admin</option>
+                <option value="super_admin">Super Admin</option>
+              </select>
+              <button
+                onClick={(e) => { e.stopPropagation(); handleRoleUpdate(user.id); }}
+                className="px-2 py-1 border border-transparent text-xs font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700"
+              >
+                Save
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); setEditingRoleForUser(null); }}
+                className="px-2 py-1 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+            </div>
+          );
+        }
+        return (
+          <div className="flex items-center space-x-2">
+            <span>{user.role}</span>
+            {auth.username !== user.username && (
+              <button 
+                onClick={(e) => { e.stopPropagation(); handleRoleChangeInitiate(user);}}
+                className="text-blue-600 hover:text-blue-800 text-xs"
+              >
+                Edit
+              </button>
+            )}
+            {auth.username === user.username && user.role === 'super_admin' && users.filter(u => u.role === 'super_admin').length <= 1 && (
+              <span className="text-xs text-gray-400 italic">(Cannot change role - only Super Admin)</span>
+            )}
+          </div>
+        );
+      }
+    },
+    { 
+      key: 'is_active', 
+      header: 'Status', 
+      sortable: true, 
+      render: (user) => (
+        <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
+          user.is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
+        }`}>
+          {user.is_active ? 'Active' : 'Inactive'}
+        </span>
+      ) 
+    },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (user) => user.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/A' },
+    {
+      key: 'actions',
+      header: 'Actions',
+      render: (user) => (
+        <div className="space-x-2">
+          {user.is_active ? (
+            <button
+              onClick={(e) => { e.stopPropagation(); handleDeactivate(user.id, user.username);}}
+              className="text-yellow-600 hover:text-yellow-900 disabled:text-gray-400 text-xs"
+              disabled={auth.username === user.username && users.filter(u => u.role === 'super_admin' && u.is_active).length <= 1}
+            >
+              Deactivate
+            </button>
+          ) : (
+            <button
+              onClick={(e) => { e.stopPropagation(); handleActivate(user.id, user.username);}}
+              className="text-green-600 hover:text-green-900 text-xs"
+            >
+              Activate
+            </button>
+          )}
+          <button
+            onClick={(e) => { e.stopPropagation(); handleDelete(user.id, user.username);}}
+            className="text-red-600 hover:text-red-900 disabled:text-gray-400 text-xs"
+            disabled={auth.username === user.username}
+          >
+            Delete
+          </button>
+        </div>
+      )
+    }
+  ];
 
   return (
     <div className="container mx-auto p-4">
@@ -122,110 +256,23 @@ const SuperAdminDashboard: React.FC = () => {
           {feedback.message}
         </div>
       )}
+      {/* Display general error if users array is empty and not loading */}
+      {error && users.length === 0 && !isLoading && <div className="text-red-500 bg-red-100 p-3 rounded mb-4">Error: {error}</div>}
 
-      {error && users.length > 0 && <p className="text-red-500 bg-red-100 p-3 rounded mb-4">Error fetching updates: {error}</p>}
 
-      <div className="overflow-x-auto bg-white shadow rounded-lg">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Username</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Role</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
-            </tr>
-          </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
-            {users.map(user => (
-              <tr key={user.id}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{user.username}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{user.email || 'N/A'}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  {editingRoleForUser === user.id ? (
-                    <div className="flex items-center space-x-2">
-                      <select
-                        value={selectedRole}
-                        onChange={(e) => setSelectedRole(e.target.value as 'user' | 'admin' | 'super_admin')}
-                        className="block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
-                        // Use auth.username for comparison
-                        disabled={auth.username === user.username && users.filter(u => u.role === 'super_admin').length <= 1 && selectedRole !== 'super_admin'}
-                      >
-                        <option value="user">User</option>
-                        <option value="admin">Admin</option>
-                        <option value="super_admin">Super Admin</option>
-                      </select>
-                      <button
-                        onClick={() => handleRoleUpdate(user.id)}
-                        className="px-3 py-1.5 border border-transparent text-xs font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
-                      >
-                        Save
-                      </button>
-                      <button
-                        onClick={() => setEditingRoleForUser(null)}
-                        className="px-3 py-1.5 border border-gray-300 text-xs font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="flex items-center space-x-2">
-                      <span>{user.role}</span>
-                      {/* Use auth.username for comparison */}
-                      {auth.username !== user.username && ( 
-                         <button 
-                            onClick={() => handleRoleChangeInitiate(user)}
-                            className="text-blue-600 hover:text-blue-800 text-xs"
-                            // disabled={auth.username === user.username} // This logic seems correct for preventing edit button for self
-                          >
-                           Edit
-                          </button>
-                      )}
-                       {auth.username === user.username && user.role === 'super_admin' && users.filter(u => u.role === 'super_admin').length <= 1 && (
-                        <span className="text-xs text-gray-400 italic">(Cannot change role - only Super Admin)</span>
-                      )}
-                    </div>
-                  )}
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm">
-                  <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${
-                    user.is_active ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'
-                  }`}>
-                    {user.is_active ? 'Active' : 'Inactive'}
-                  </span>
-                </td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium space-x-2">
-                  {user.is_active ? (
-                    <button
-                      onClick={() => handleDeactivate(user.id, user.username)}
-                      className="text-yellow-600 hover:text-yellow-900 disabled:text-gray-400"
-                      // Use auth.username for comparison
-                      disabled={auth.username === user.username && users.filter(u => u.role === 'super_admin' && u.is_active).length <= 1}
-                    >
-                      Deactivate
-                    </button>
-                  ) : (
-                    <button
-                      onClick={() => handleActivate(user.id, user.username)}
-                      className="text-green-600 hover:text-green-900"
-                    >
-                      Activate
-                    </button>
-                  )}
-                  <button
-                    onClick={() => handleDelete(user.id, user.username)}
-                    className="text-red-600 hover:text-red-900 disabled:text-gray-400"
-                    // Use auth.username for comparison
-                    disabled={auth.username === user.username} // Cannot delete self
-                  >
-                    Delete
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <DataTable
+        columns={columns}
+        data={users}
+        isLoading={isLoading}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={handlePageChange}
+        itemsPerPage={itemsPerPage}
+        totalItems={totalUsers}
+        sortColumn={sortBy}
+        sortOrder={sortOrder}
+        onSort={handleSort}
+      />
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces pagination and sorting capabilities across various list views in the application, enhancing usability for large datasets.

Backend:
- Updated list API endpoints (`/api/superadmin/users`, `/api/documents`, `/api/patches`, `/api/links`, `/api/misc_files`) to accept `page`, `per_page`, `sort_by`, and `sort_order` query parameters.
- These endpoints now return paginated data including total item counts and total pages.
- Added validation for pagination and sorting parameters.

Frontend:
- Enhanced the `DataTable.tsx` component to support:
    - Props for pagination state (`currentPage`, `totalPages`, etc.) and `onPageChange` callback.
    - Props for sorting state (`sortColumn`, `sortOrder`) and `onSort` callback.
    - UI for pagination controls (Next/Previous buttons, page numbers).
    - Clickable column headers for sorting with visual indicators.
- Updated API service functions in `api.ts` to send pagination/sorting parameters and handle new paginated response DTOs.
- Integrated the enhanced `DataTable` into:
    - `SuperAdminDashboard.tsx` (User list)
    - `DocumentsView.tsx` (Documents list)
    - `PatchesView.tsx` (Patches list)
    - `LinksView.tsx` (Links list)
    - `MiscView.tsx` (Miscellaneous Files list)
- Each view now manages its own pagination and sorting state, and calls the updated API services accordingly.
- Existing filtering functionalities in these views have been preserved alongside the new features.