### PR TITLE
Fix: Correct super_admin authorization in admin form components

### DIFF
--- a/frontend/src/components/admin/AdminDocumentEntryForm.tsx
+++ b/frontend/src/components/admin/AdminDocumentEntryForm.tsx
@@ -228,7 +228,7 @@ const AdminDocumentEntryForm: React.FC<AdminDocumentEntryFormProps> = ({
 
   const documentTypes = ["Guide", "Manual", "API Reference", "Datasheet", "Whitepaper", "Specification", "Other"];
 
-  if (!isAuthenticated || role !== 'admin') return null;
+  if (!isAuthenticated || !['admin', 'super_admin'].includes(role)) return null;
 
   return (
     <form onSubmit={handleSubmit(onSubmit, onFormError)} className="space-y-6 bg-white p-6 rounded-lg shadow-md border border-gray-200">

--- a/frontend/src/components/admin/AdminLinkEntryForm.tsx
+++ b/frontend/src/components/admin/AdminLinkEntryForm.tsx
@@ -320,7 +320,7 @@ const AdminLinkEntryForm: React.FC<AdminLinkEntryFormProps> = ({
   };
 
 
-  if (!isAuthenticated || role !== 'admin') return null;
+  if (!isAuthenticated || !['admin', 'super_admin'].includes(role)) return null;
 
   return (
     // Use RHF handleSubmit, pass onSubmit and optional onFormError

--- a/frontend/src/components/admin/AdminMiscCategoryForm.tsx
+++ b/frontend/src/components/admin/AdminMiscCategoryForm.tsx
@@ -115,7 +115,7 @@ const AdminMiscCategoryForm: React.FC<AdminMiscCategoryFormProps> = ({
   };
 
 
-  if (!isAuthenticated || role !== 'admin') {
+  if (!isAuthenticated || !['admin', 'super_admin'].includes(role)) {
     return <p>You are not authorized to manage categories.</p>;
   }
 

--- a/frontend/src/components/admin/AdminPatchEntryForm.tsx
+++ b/frontend/src/components/admin/AdminPatchEntryForm.tsx
@@ -302,7 +302,7 @@ const AdminPatchEntryForm: React.FC<AdminPatchEntryFormProps> = ({
     toast.error("Please correct the errors highlighted in the form.");
   };
 
-  if (!isAuthenticated || role !== 'admin') return null;
+  if (!isAuthenticated || !['admin', 'super_admin'].includes(role)) return null;
   // console.log("Current softwareList:", softwareList); // Removed console.log
 
   return (

--- a/frontend/src/components/admin/AdminUploadToMiscForm.tsx
+++ b/frontend/src/components/admin/AdminUploadToMiscForm.tsx
@@ -176,7 +176,7 @@ const AdminUploadToMiscForm: React.FC<AdminUploadToMiscFormProps> = ({
     toast.error("Please correct the errors highlighted in the form.");
   };
   
-  if (!isAuthenticated || role !== 'admin') {
+  if (!isAuthenticated || !['admin', 'super_admin'].includes(role)) {
       return null;
   }
 


### PR DESCRIPTION
This commit addresses issues where 'super_admin' users were either denied access or encountered UI rendering problems (e.g., "white box") when trying to use admin forms for creating/editing content.

The internal authorization checks within several admin form components were too strict, only allowing the 'admin' role. These have been updated to also include the 'super_admin' role.

Affected components:
- `AdminMiscCategoryForm.tsx`: Changed internal check to allow 'super_admin', resolving "You are not authorized..." message.
- `AdminUploadToMiscForm.tsx`: Changed internal check to allow 'super_admin', preventing it from returning null.
- `AdminDocumentEntryForm.tsx`: Changed internal check to allow 'super_admin', preventing it from returning null.
- `AdminLinkEntryForm.tsx`: Changed internal check to allow 'super_admin', preventing it from returning null.
- `AdminPatchEntryForm.tsx`: Changed internal check to allow 'super_admin', preventing it from returning null.

These changes ensure that 'super_admin' users can correctly access and view these forms, consistent with their intended privileges.