### PR TITLE
fix: Address feedback for admin version management UI

### DIFF
--- a/frontend/src/components/admin/versions/AdminVersionsPage.tsx
+++ b/frontend/src/components/admin/versions/AdminVersionsPage.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import AdminVersionsTable from './AdminVersionsTable';
 import AdminVersionForm from './AdminVersionForm';
 import { AdminSoftwareVersion, Software } from '../../../services/api'; // Adjust path as needed
 import { deleteAdminVersion, fetchSoftware } from '../../../services/api'; // Adjust path as needed
-import ConfirmationModal from '../../ConfirmationModal'; // Adjust path as needed
-import Modal from '../../Modal'; // Generic Modal for the form
+import ConfirmationModal from '../../shared/ConfirmationModal'; // Adjust path as needed
+import Modal from '../../shared/Modal'; // Generic Modal for the form
 
 const AdminVersionsPage: React.FC = () => {
   const [isFormModalOpen, setIsFormModalOpen] = useState(false);
@@ -153,7 +153,7 @@ const AdminVersionsPage: React.FC = () => {
           onConfirm={confirmDelete}
           onCancel={cancelDelete}
           confirmButtonText="Delete"
-          confirmButtonColor="red"
+          confirmButtonVariant="danger" // Changed from confirmButtonColor
         />
       )}
     </div>

--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center">
+      <div className="relative mx-auto p-5 border w-full max-w-2xl shadow-lg rounded-md bg-white">
+        <div className="mt-3 text-center">
+          {title && (
+            <h3 className="text-lg leading-6 font-medium text-gray-900">{title}</h3>
+          )}
+          <div className="mt-2 px-7 py-3">
+            {children}
+          </div>
+          <div className="items-center px-4 py-3">
+            <button
+              id="ok-btn"
+              className="px-4 py-2 bg-gray-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-300"
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,6 +16,7 @@ import {
   // DocumentType, Link, Patch, Software, SoftwareVersion, MiscCategory, MiscFile
   // should ideally be imported from a central types.ts file.
 } from '../types'; // Assuming '../types' will eventually export these
+export type { Software } from '../types'; // Re-exporting Software type
 
 // --- Type Definitions (Ensure these are consistent with your backend and UI needs) ---
 // Base entity types (assuming these are defined in '../types' or need to be defined here)


### PR DESCRIPTION
This commit incorporates several fixes based on your feedback for the admin version management feature:

- Modal Usage:
    - Created a new generic Modal component (`frontend/src/components/shared/Modal.tsx`).
    - Updated `AdminVersionsPage.tsx` to correctly import and use this shared modal for the add/edit version form.
- ConfirmationModal:
    - Corrected the import path for `ConfirmationModal` in `AdminVersionsPage.tsx`.
    - Changed the `confirmButtonColor` prop to the supported `confirmButtonVariant="danger"` when using `ConfirmationModal`.
- Type Export:
    - Ensured the `Software` type is re-exported from `frontend/src/services/api.ts` to make it available for import by other modules.
- useEffect Import:
    - Verified that `useEffect` is correctly imported in `AdminVersionsPage.tsx`.
- Role Access:
    - Confirmed that version management features are accessible to both 'admin' and 'super_admin' roles in the backend API, frontend routing, and sidebar navigation.