### PR TITLE
feat: Implement User Favorites/Bookmarks

### DIFF
--- a/database.py
+++ b/database.py
@@ -71,3 +71,189 @@ def init_db(db_path: str):
 
 # Note: No other functions needed in this file for basic connection and init.
 # Data fetching logic is now in app.py or will be called by app.py's route handlers.
+
+# Favorite Management Functions
+
+def add_favorite(db, user_id, item_id, item_type):
+    """Adds an item to user's favorites."""
+    try:
+        cursor = db.execute(
+            "INSERT INTO user_favorites (user_id, item_id, item_type) VALUES (?, ?, ?)",
+            (user_id, item_id, item_type)
+        )
+        db.commit()
+        return cursor.lastrowid
+    except sqlite3.IntegrityError:
+        # This typically means the (user_id, item_id, item_type) combination already exists,
+        # which is fine, we can treat it as "already favorited".
+        # For the API, we might want to fetch the existing one.
+        # For now, returning None to indicate "no new row inserted" or an issue.
+        print(f"DB_FAVORITES: IntegrityError when adding favorite for user {user_id}, item {item_id}, type {item_type}. Item might already be a favorite.")
+        return None
+    except sqlite3.Error as e:
+        print(f"DB_FAVORITES: Error adding favorite for user {user_id}, item {item_id}, type {item_type}: {e}")
+        return None
+
+def remove_favorite(db, user_id, item_id, item_type):
+    """Removes an item from user's favorites."""
+    try:
+        cursor = db.execute(
+            "DELETE FROM user_favorites WHERE user_id = ? AND item_id = ? AND item_type = ?",
+            (user_id, item_id, item_type)
+        )
+        db.commit()
+        return cursor.rowcount > 0  # True if a row was deleted
+    except sqlite3.Error as e:
+        print(f"DB_FAVORITES: Error removing favorite for user {user_id}, item {item_id}, type {item_type}: {e}")
+        return False
+
+def get_favorite_status(db, user_id, item_id, item_type):
+    """Checks if a specific item is favorited by the user."""
+    try:
+        cursor = db.execute(
+            "SELECT id, user_id, item_id, item_type, created_at FROM user_favorites WHERE user_id = ? AND item_id = ? AND item_type = ?",
+            (user_id, item_id, item_type)
+        )
+        return cursor.fetchone() # Returns a Row object or None
+    except sqlite3.Error as e:
+        print(f"DB_FAVORITES: Error fetching favorite status for user {user_id}, item {item_id}, type {item_type}: {e}")
+        return None
+
+def get_user_favorites(db, user_id, page, per_page, item_type_filter=None):
+    """Retrieves a paginated list of a user's favorited items with details."""
+    offset = (page - 1) * per_page
+    
+    # Base parts of the UNION ALL query
+    # Each SELECT should have the same number and type of columns.
+    # Columns: favorite_id, item_id, item_type, favorited_at, name, description, software_name, software_id, version_number
+    
+    select_clauses = []
+
+    # Documents
+    documents_sql = """
+    SELECT
+        uf.id AS favorite_id, uf.item_id, uf.item_type, uf.created_at AS favorited_at,
+        d.doc_name AS name, d.description, s.name AS software_name, s.id AS software_id,
+        NULL AS version_number, NULL as version_id
+    FROM user_favorites uf
+    JOIN documents d ON uf.item_id = d.id AND uf.item_type = 'document'
+    JOIN software s ON d.software_id = s.id
+    WHERE uf.user_id = :user_id
+    """
+    if item_type_filter == 'document' or not item_type_filter:
+        select_clauses.append(documents_sql)
+
+    # Patches
+    patches_sql = """
+    SELECT
+        uf.id AS favorite_id, uf.item_id, uf.item_type, uf.created_at AS favorited_at,
+        p.patch_name AS name, p.description, s.name AS software_name, s.id AS software_id,
+        v.version_number AS version_number, v.id as version_id
+    FROM user_favorites uf
+    JOIN patches p ON uf.item_id = p.id AND uf.item_type = 'patch'
+    JOIN versions v ON p.version_id = v.id
+    JOIN software s ON v.software_id = s.id
+    WHERE uf.user_id = :user_id
+    """
+    if item_type_filter == 'patch' or not item_type_filter:
+        select_clauses.append(patches_sql)
+
+    # Links
+    links_sql = """
+    SELECT
+        uf.id AS favorite_id, uf.item_id, uf.item_type, uf.created_at AS favorited_at,
+        l.title AS name, l.description, s.name AS software_name, s.id AS software_id,
+        v.version_number AS version_number, v.id as version_id
+    FROM user_favorites uf
+    JOIN links l ON uf.item_id = l.id AND uf.item_type = 'link'
+    JOIN versions v ON l.version_id = v.id
+    JOIN software s ON v.software_id = s.id
+    WHERE uf.user_id = :user_id
+    """
+    if item_type_filter == 'link' or not item_type_filter:
+        select_clauses.append(links_sql)
+
+    # Misc Files
+    misc_files_sql = """
+    SELECT
+        uf.id AS favorite_id, uf.item_id, uf.item_type, uf.created_at AS favorited_at,
+        mf.user_provided_title AS name, mf.user_provided_description AS description,
+        cat.name AS software_name, NULL AS software_id, -- Using category name as a stand-in for software_name for consistency
+        NULL AS version_number, NULL as version_id
+    FROM user_favorites uf
+    JOIN misc_files mf ON uf.item_id = mf.id AND uf.item_type = 'misc_file'
+    JOIN misc_categories cat ON mf.misc_category_id = cat.id
+    WHERE uf.user_id = :user_id
+    """
+    if item_type_filter == 'misc_file' or not item_type_filter:
+        select_clauses.append(misc_files_sql)
+
+    # Software
+    software_sql = """
+    SELECT
+        uf.id AS favorite_id, uf.item_id, uf.item_type, uf.created_at AS favorited_at,
+        s.name AS name, s.description, s.name AS software_name, s.id AS software_id,
+        NULL AS version_number, NULL as version_id
+    FROM user_favorites uf
+    JOIN software s ON uf.item_id = s.id AND uf.item_type = 'software'
+    WHERE uf.user_id = :user_id
+    """
+    if item_type_filter == 'software' or not item_type_filter:
+        select_clauses.append(software_sql)
+    
+    # Versions
+    versions_sql = """
+    SELECT
+        uf.id AS favorite_id, uf.item_id, uf.item_type, uf.created_at AS favorited_at,
+        v.version_number AS name, v.changelog AS description, s.name AS software_name, s.id AS software_id,
+        v.version_number AS version_number, v.id as version_id
+    FROM user_favorites uf
+    JOIN versions v ON uf.item_id = v.id AND uf.item_type = 'version'
+    JOIN software s ON v.software_id = s.id
+    WHERE uf.user_id = :user_id
+    """
+    if item_type_filter == 'version' or not item_type_filter:
+        select_clauses.append(versions_sql)
+
+    if not select_clauses: # No valid item types selected or available
+        return [], 0
+
+    # Construct the full query
+    query_sql = " UNION ALL ".join(select_clauses)
+    
+    # Add item_type filter to each part of the UNION if item_type_filter is present
+    # This is slightly redundant with the conditional inclusion but ensures correctness if logic changes
+    if item_type_filter:
+        query_sql = query_sql.replace("WHERE uf.user_id = :user_id", f"WHERE uf.user_id = :user_id AND uf.item_type = '{item_type_filter}'")
+
+    # Order by favorited_at and then apply pagination
+    query_sql = f"SELECT * FROM ({query_sql}) ORDER BY favorited_at DESC LIMIT :limit OFFSET :offset"
+    
+    # Count query
+    count_query_parts = []
+    base_count_sql = "SELECT COUNT(uf.id) FROM user_favorites uf WHERE uf.user_id = :user_id"
+    if item_type_filter:
+        base_count_sql += f" AND uf.item_type = '{item_type_filter}'"
+    
+    # The total count is simpler: just count from user_favorites table with the filter
+    count_sql = base_count_sql
+    
+    try:
+        # Fetch items
+        cursor = db.execute(query_sql, {"user_id": user_id, "limit": per_page, "offset": offset})
+        items = cursor.fetchall() # List of Row objects
+
+        # Fetch total count
+        cursor = db.execute(count_sql, {"user_id": user_id})
+        total_count_row = cursor.fetchone()
+        total_count = total_count_row[0] if total_count_row else 0
+        
+        return items, total_count
+    except sqlite3.Error as e:
+        print(f"DB_FAVORITES: Error fetching user favorites for user {user_id}: {e}")
+        return [], 0
+    except Exception as e:
+        print(f"DB_FAVORITES: General error fetching user favorites for user {user_id}: {e}")
+        # Potentially log more details about the query_sql for debugging
+        print(f"Problematic Query: {query_sql}")
+        return [], 0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import MiscView from './views/MiscView';
 import SearchResultsView from './views/SearchResultsView';
 import LoginPage from './views/LoginPage';
 import RegisterPage from './views/RegisterPage';
+import FavoritesView from './views/FavoritesView'; // Added FavoritesView
 
 // Optional: You might create this later for better route protection
 // import ProtectedRoute from './components/ProtectedRoute';
@@ -41,6 +42,7 @@ function App() {
           <Route path="misc" element={<MiscView />} />
           <Route path="search" element={<SearchResultsView />} />
           <Route path="profile" element={<UserProfilePage />} />
+          <Route path="favorites" element={<FavoritesView />} /> {/* Added Favorites Route */}
           
           {/* Admin and Super Admin Routes */}
           <Route 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -8,10 +8,11 @@ import {
   MoreHorizontal,
   UploadCloud as UploadIcon, // <-- Import an icon for Upload
   Settings as SettingsIcon, // Icon for "Manage Versions"
-  // LogIn as LogInIcon, // Keep if you want login/register here, but usually in Header
-  // UserPlus as RegisterIcon // Keep if you want login/register here
+  Star as StarIcon // Added for Favorites
+  // LogIn as LogInIcon, 
+  // UserPlus as RegisterIcon 
 } from 'lucide-react';
-import { useAuth } from '../context/AuthContext'; // <-- Import useAuth hook
+import { useAuth } from '../context/AuthContext'; 
 
 interface SidebarProps {
   collapsed: boolean;
@@ -55,6 +56,12 @@ const Sidebar: React.FC<SidebarProps> = ({ collapsed }) => {
       path: '/misc',
       label: 'Misc',
       icon: (isCollapsed) => <MoreHorizontal size={isCollapsed ? 24 : 20} />,
+    },
+    {
+      path: '/favorites',
+      label: 'Favorites',
+      icon: (isCollapsed) => <StarIcon size={isCollapsed ? 24 : 20} />,
+      requiresAuth: true,
     },
     // Admin-specific links
     {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -5,13 +5,27 @@ export interface Software {
   id: number;
   name: string;
   description: string | null;
+  is_favorited?: boolean;
+  favorite_id?: number;
 }
 
 // --- Version Type (from /api/versions_for_software for dropdowns) ---
+// Also used for full version details in some contexts
 export interface SoftwareVersion {
   id: number; // This is the version_id from the 'versions' table
+  software_id?: number; // Added for consistency, though not always in dropdowns
+  software_name?: string; // Added for consistency
   version_number: string;
-  // release_date?: string; // Optional: if your API returns it and you need it in the dropdown display
+  release_date?: string | null;
+  main_download_link?: string | null;
+  changelog?: string | null;
+  known_bugs?: string | null;
+  created_by_user_id?: number;
+  created_at?: string;
+  updated_by_user_id?: number | null;
+  updated_at?: string | null;
+  is_favorited?: boolean;
+  favorite_id?: number;
 }
 
 // --- Document Types ---
@@ -32,6 +46,8 @@ export interface Document {
   updated_at?: string;
   uploaded_by_username?: string;
   updated_by_username?: string;
+  is_favorited?: boolean;
+  favorite_id?: number;
 }
 
 // --- Patch Types ---
@@ -60,6 +76,8 @@ export interface Patch {
   patch_by_developer?: string | null;
   uploaded_by_username?: string;
   updated_by_username?: string;
+  is_favorited?: boolean;
+  favorite_id?: number;
 }
 
 // --- Link Types ---
@@ -86,6 +104,8 @@ export interface Link {
   updated_at?: string;
   uploaded_by_username?: string;
   updated_by_username?: string;
+  is_favorited?: boolean;
+  favorite_id?: number;
   // category?: string; // Removed as it's not in the current backend schema for links
 }
 
@@ -200,6 +220,8 @@ export interface MiscFile {
   updated_at?: string;
   uploaded_by_username?: string;
   updated_by_username?: string;
+  is_favorited?: boolean;
+  favorite_id?: number;
 }
 // No specific EditMiscFilePayload type is defined here as edit operations for misc files
 // (like replacing the file or changing metadata) will likely use FormData via editAdminMiscFile.

--- a/frontend/src/views/FavoritesView.tsx
+++ b/frontend/src/views/FavoritesView.tsx
@@ -1,0 +1,266 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { Star, FileText, Puzzle, Link2 as LinkIcon, Archive as FileArchive, Package, Tag } from 'lucide-react'; // Using Link2 for LinkIcon to avoid conflict
+import {
+  getUserFavoritesApi,
+  PaginatedFavoritesResponse,
+  DetailedFavoriteItem,
+  FavoriteItemType,
+  addFavoriteApi,
+  removeFavoriteApi,
+  getFavoriteStatusApi, // To initialize favorite states correctly if needed, though primary data comes from getUserFavoritesApi
+} from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import LoadingState from '../components/LoadingState';
+import ErrorState from '../components/ErrorState';
+import { API_BASE_URL } from '../config';
+
+const FavoritesView: React.FC = () => {
+  const { isAuthenticated, isAuthLoading } = useAuth();
+  const [favorites, setFavorites] = useState<DetailedFavoriteItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalFavorites, setTotalFavorites] = useState(0);
+  const [itemsPerPage, setItemsPerPage] = useState(10); // Or your default
+
+  // This state will primarily be used to manage the filled/unfilled star for items on this page
+  // It's populated by the `is_favorited` and `favorite_id` coming directly from the `DetailedFavoriteItem`
+  const [favoritedItems, setFavoritedItems] = useState<Map<string, { favoriteId: number | undefined }>>(new Map());
+
+  const mapItemTypeToIcon = (itemType: FavoriteItemType) => {
+    switch (itemType) {
+      case 'document': return <FileText size={18} className="mr-2 text-blue-500" />;
+      case 'patch': return <Puzzle size={18} className="mr-2 text-green-500" />;
+      case 'link': return <LinkIcon size={18} className="mr-2 text-purple-500" />;
+      case 'misc_file': return <FileArchive size={18} className="mr-2 text-yellow-500" />;
+      case 'software': return <Package size={18} className="mr-2 text-indigo-500" />;
+      case 'version': return <Tag size={18} className="mr-2 text-pink-500" />;
+      default: return <Star size={18} className="mr-2 text-gray-500" />;
+    }
+  };
+  
+  const getItemPageLink = (item: DetailedFavoriteItem): string => {
+    switch (item.item_type) {
+      case 'document':
+        return `/documents?highlight=${item.item_id}&software_id=${item.software_id || ''}`;
+      case 'patch':
+        return `/patches?highlight=${item.item_id}&software_id=${item.software_id || ''}&version_id=${item.version_id || ''}`;
+      case 'link':
+         // For external links, the item.name might be the URL, or a specific field if available
+         // If it's an uploaded file link, construct path similar to other file types
+        if (item.name && (item.name.startsWith('http://') || item.name.startsWith('https://'))) { // Assuming 'name' holds URL for external links for now
+            return item.name;
+        }
+        // Fallback for internal links or if name is not a URL
+        return `/links?highlight=${item.item_id}&software_id=${item.software_id || ''}&version_id=${item.version_id || ''}`;
+      case 'misc_file':
+        return `/misc?highlight=${item.item_id}`; // Assuming a general misc view or specific category view
+      case 'software':
+        return `/documents?software_id=${item.item_id}`; // Example: link to documents of that software
+      case 'version':
+        return `/patches?software_id=${item.software_id || ''}&version_id=${item.item_id}`; // Example: link to patches of that version
+      default:
+        return '#';
+    }
+  };
+
+
+  const loadFavorites = useCallback(async () => {
+    if (!isAuthenticated) {
+      setIsLoading(false);
+      setError("Please log in to view your favorites.");
+      setFavorites([]);
+      return;
+    }
+    setIsLoading(true);
+    setError(null);
+    setFeedbackMessage(null);
+
+    try {
+      const response: PaginatedFavoritesResponse = await getUserFavoritesApi(currentPage, itemsPerPage);
+      setFavorites(response.favorites);
+      setTotalPages(response.total_pages);
+      setTotalFavorites(response.total_favorites);
+      // Update favoritedItems map based on the fetched favorites
+      const newFavoritedItems = new Map<string, { favoriteId: number | undefined }>();
+      response.favorites.forEach(fav => {
+        newFavoritedItems.set(`${fav.item_type}-${fav.item_id}`, { favoriteId: fav.favorite_id });
+      });
+      setFavoritedItems(newFavoritedItems);
+    } catch (err: any) {
+      setError(err.message || 'Failed to fetch favorites.');
+      setFavorites([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isAuthenticated, currentPage, itemsPerPage]);
+
+  useEffect(() => {
+    if (!isAuthLoading) { // Only load favorites once auth status is confirmed
+        loadFavorites();
+    }
+  }, [loadFavorites, isAuthLoading]);
+
+  const handleFavoriteToggle = async (item: DetailedFavoriteItem) => {
+    if (!isAuthenticated) {
+      setFeedbackMessage("Please log in to manage favorites.");
+      return;
+    }
+
+    const uniqueKey = `${item.item_type}-${item.item_id}`;
+    const currentStatus = favoritedItems.get(uniqueKey);
+    const isCurrentlyFavorited = !!currentStatus?.favoriteId;
+
+    // Optimistic UI update: Remove from list immediately if un-favoriting
+    if (isCurrentlyFavorited) {
+      setFavorites(prevFavorites => prevFavorites.filter(fav => fav.favorite_id !== currentStatus.favoriteId));
+      setFavoritedItems(prevMap => {
+        const newMap = new Map(prevMap);
+        newMap.set(uniqueKey, { favoriteId: undefined });
+        return newMap;
+      });
+    } else {
+      // For adding, we'd typically re-fetch or add to list, but this page only shows existing favorites.
+      // So, adding back is less of a concern here unless the item was incorrectly removed optimistically.
+      // For now, if an item is re-favorited (which shouldn't happen from this page if it's already gone),
+      // we'll just update the map. The item won't reappear unless the list is reloaded.
+       setFavoritedItems(prevMap => {
+        const newMap = new Map(prevMap);
+        newMap.set(uniqueKey, { favoriteId: -1 }); // Placeholder, will be updated by actual ID
+        return newMap;
+      });
+    }
+    setFeedbackMessage(null);
+
+    try {
+      if (isCurrentlyFavorited && typeof currentStatus?.favoriteId === 'number') {
+        await removeFavoriteApi(item.item_id, item.item_type);
+        setFeedbackMessage(`"${item.name}" removed from favorites.`);
+        // State already updated optimistically. Optionally, re-fetch to confirm.
+        // loadFavorites(); // Or just ensure local state is consistent
+      } else {
+        // This case (adding a favorite) should ideally not be triggered from the favorites page
+        // if an item is only shown when it *is* a favorite.
+        // However, if it's possible due to some UI inconsistency:
+        const newFavoriteEntry = await addFavoriteApi(item.item_id, item.item_type);
+        setFavoritedItems(prevMap => {
+            const newMap = new Map(prevMap);
+            newMap.set(uniqueKey, { favoriteId: newFavoriteEntry.id });
+            return newMap;
+        });
+        setFeedbackMessage(`"${item.name}" added to favorites.`);
+        // Item might not be in the list if it was removed optimistically and re-added.
+        // A full reload might be best here if adding is a possible action.
+        loadFavorites();
+      }
+    } catch (error: any) {
+      console.error("Failed to toggle favorite:", error);
+      setFeedbackMessage(error?.response?.data?.msg || error.message || "Failed to update favorite status.");
+      // Revert optimistic update
+      loadFavorites(); // Re-fetch to get consistent state
+    }
+  };
+
+  if (isAuthLoading || isLoading) {
+    return <LoadingState message="Loading favorites..." />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="text-center py-10">
+        <p className="text-lg text-gray-600">Please <Link to="/login" className="text-blue-600 hover:underline">log in</Link> to view your favorites.</p>
+      </div>
+    );
+  }
+  
+  if (error) {
+    return <ErrorState message={error} onRetry={loadFavorites} />;
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center space-x-3 mb-6">
+        <Star size={32} className="text-yellow-500" />
+        <h1 className="text-3xl font-bold text-gray-800">My Favorites</h1>
+      </div>
+
+      {feedbackMessage && (
+        <div className={`p-3 my-2 rounded text-sm ${feedbackMessage.includes("removed") || feedbackMessage.includes("Failed") ? 'bg-red-100 text-red-700' : 'bg-green-100 text-green-700'}`}>
+          {feedbackMessage}
+        </div>
+      )}
+
+      {favorites.length === 0 ? (
+        <div className="text-center py-10">
+          <Star size={48} className="mx-auto text-gray-400 mb-4" />
+          <p className="text-xl text-gray-600">You haven't favorited any items yet.</p>
+          <p className="text-sm text-gray-500 mt-2">Start exploring and mark your favorites by clicking the star icon!</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {favorites.map(item => (
+            <div key={item.favorite_id} className="bg-white shadow-sm rounded-lg p-4 flex items-center justify-between hover:shadow-md transition-shadow">
+              <div className="flex items-center">
+                {mapItemTypeToIcon(item.item_type)}
+                <div>
+                  <Link 
+                    to={getItemPageLink(item)} 
+                    target={item.item_type === 'link' && (item.name.startsWith('http://') || item.name.startsWith('https://')) ? '_blank' : '_self'}
+                    rel={item.item_type === 'link' && (item.name.startsWith('http://') || item.name.startsWith('https://')) ? 'noopener noreferrer' : ''}
+                    className="text-lg font-semibold text-blue-600 hover:underline"
+                  >
+                    {item.name}
+                  </Link>
+                  <p className="text-xs text-gray-500 capitalize">
+                    Type: {item.item_type.replace('_', ' ')}
+                    {item.software_name && ` • Software: ${item.software_name}`}
+                    {item.version_number && ` • Version: ${item.version_number}`}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    Favorited on: {new Date(item.favorited_at).toLocaleDateString()}
+                  </p>
+                </div>
+              </div>
+              <button
+                onClick={() => handleFavoriteToggle(item)}
+                className={`p-2 rounded-full ${favoritedItems.get(`${item.item_type}-${item.item_id}`)?.favoriteId ? 'text-yellow-500' : 'text-gray-400'} hover:text-yellow-600 focus:outline-none`}
+                title={favoritedItems.get(`${item.item_type}-${item.item_id}`)?.favoriteId ? "Remove from Favorites" : "Add to Favorites (should not happen here)"}
+              >
+                <Star size={20} className={favoritedItems.get(`${item.item_type}-${item.item_id}`)?.favoriteId ? "fill-current" : ""} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Pagination Controls */}
+      {totalPages > 1 && (
+        <div className="flex justify-between items-center mt-8">
+          <button
+            onClick={() => setCurrentPage(prev => Math.max(prev - 1, 1))}
+            disabled={currentPage === 1}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            Previous
+          </button>
+          <span className="text-sm text-gray-700">
+            Page {currentPage} of {totalPages} (Total: {totalFavorites} items)
+          </span>
+          <button
+            onClick={() => setCurrentPage(prev => Math.min(prev + 1, totalPages))}
+            disabled={currentPage === totalPages}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FavoritesView;

--- a/schema.sql
+++ b/schema.sql
@@ -2,6 +2,7 @@
 
 -- Drop tables in reverse order of dependency for clean re-initialization
 DROP TABLE IF EXISTS audit_logs;
+DROP TABLE IF EXISTS user_favorites;
 DROP TABLE IF EXISTS download_log;
 DROP TABLE IF EXISTS misc_files;
 DROP TABLE IF EXISTS misc_categories;
@@ -191,6 +192,19 @@ CREATE TRIGGER IF NOT EXISTS update_misc_files_updated_at
 AFTER UPDATE ON misc_files FOR EACH ROW BEGIN
     UPDATE misc_files SET updated_at = CURRENT_TIMESTAMP WHERE id = OLD.id;
 END;
+
+-- Table for User Favorites
+CREATE TABLE IF NOT EXISTS user_favorites (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL,
+    item_id INTEGER NOT NULL,
+    item_type TEXT NOT NULL, -- 'document', 'patch', 'link', 'misc_file', 'software', 'version'
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users (id),
+    UNIQUE (user_id, item_id, item_type)
+);
+CREATE INDEX IF NOT EXISTS idx_user_favorites_user_id ON user_favorites (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_favorites_item_id_item_type ON user_favorites (item_id, item_type);
 
 -- Table for Download Logs
 CREATE TABLE IF NOT EXISTS download_log (


### PR DESCRIPTION
This commit introduces the functionality for you to favorite or bookmark various items within the application.

Key changes include:

Backend:
- Added `user_favorites` table to the database schema to store your favorite items (linking user_id, item_id, item_type).
- Implemented new API endpoints:
    - `POST /api/favorites`: Add an item to favorites.
    - `DELETE /api/favorites/<item_type>/<item_id>`: Remove an item from favorites.
    - `GET /api/favorites`: Get a paginated list of your favorited items with details.
    - `GET /api/favorites/status/<item_type>/<item_id>`: Check if an item is favorited by you.
- Integrated favorite status (`favorite_id`) directly into the `/api/search` results when you are authenticated, optimizing data fetching.
- Ensured new endpoints are JWT protected and include audit logging.

Frontend:
- Added `Star` icon buttons to item displays in Documents, Patches, Links, Misc, and Search Results views, allowing you to toggle favorite status.
- Implemented API client functions in `services/api.ts` to interact with the new favorites endpoints.
- Updated relevant views to manage and display favorite status, including optimistic UI updates and handling API responses.
- Created a new "Favorites" page (`/favorites`):
    - Displays a list of your favorited items, fetched from the API.
    - Supports pagination and allows un-favoriting items directly from this page.
- Added a "Favorites" link to the sidebar for easy access (when you are authenticated).
- Removed inefficient client-side N+1 calls for favorite status in SearchResultsView, now relying on backend-provided data.

Further work would involve thorough testing of all new functionality across backend and frontend.