### PR TITLE
feat: Enhance admin dashboard with granular statistics

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -131,6 +131,26 @@ export type EditAdminVersionPayload = Partial<AddAdminVersionPayload>;
 // --- End of Type Definitions ---
 
 // --- Interface for Dashboard Statistics ---
+
+// Helper type for daily trends
+export interface TrendItem {
+  date: string; // For daily
+  count: number;
+}
+
+// Helper type for weekly trends
+export interface WeeklyTrendItem {
+  week_start_date: string; // For weekly
+  count: number;
+}
+
+// Helper type for content health statistics per content type
+export interface ContentTypeHealthStats {
+  missing?: number; // For missing_descriptions
+  stale?: number;   // For stale_content
+  total: number;
+}
+
 export interface RecentActivityItem {
   action_type: string;
   username: string | null; // Username can be null for system actions or if user is deleted
@@ -163,6 +183,44 @@ export interface DashboardStats {
   recent_additions?: RecentAdditionItem[]; 
   popular_downloads?: PopularDownloadItem[]; 
   documents_per_software?: DocumentsPerSoftwareItem[];
+
+  // New properties
+  user_activity_trends?: { 
+    logins: {
+      daily: TrendItem[];
+      weekly: WeeklyTrendItem[];
+    };
+    uploads: {
+      daily: TrendItem[];
+      weekly: WeeklyTrendItem[];
+    };
+  };
+
+  total_storage_utilized_bytes?: number;
+
+  download_trends?: {
+    daily: TrendItem[];
+    weekly: WeeklyTrendItem[];
+  };
+
+  content_health?: {
+    missing_descriptions: {
+      documents: ContentTypeHealthStats;
+      patches: ContentTypeHealthStats;
+      links: ContentTypeHealthStats;
+      misc_categories: ContentTypeHealthStats;
+      software: ContentTypeHealthStats;
+      misc_files: ContentTypeHealthStats;
+    };
+    stale_content: {
+      documents: ContentTypeHealthStats;
+      patches: ContentTypeHealthStats;
+      links: ContentTypeHealthStats;
+      misc_files: ContentTypeHealthStats;
+      versions: ContentTypeHealthStats;
+      misc_categories: ContentTypeHealthStats; 
+    };
+  };
 }
 // --- End of Interface for Dashboard Statistics ---
 

--- a/frontend/src/views/AdminDashboardPage.test.tsx
+++ b/frontend/src/views/AdminDashboardPage.test.tsx
@@ -1,0 +1,274 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom'; // For RouterLink components
+import AdminDashboardPage from './AdminDashboardPage';
+import { fetchDashboardStats, fetchSystemHealth, DashboardStats, SystemHealth, RecentActivityItem, RecentAdditionItem, PopularDownloadItem, DocumentsPerSoftwareItem } from '../services/api'; 
+// Import TrendItem, WeeklyTrendItem, ContentTypeHealthStats if they were moved to types/index.ts, 
+// otherwise they are implicitly part of DashboardStats from api.ts
+
+// Mock API services
+jest.mock('../services/api', () => ({
+  ...jest.requireActual('../services/api'), // Preserve other exports
+  fetchDashboardStats: jest.fn(),
+  fetchSystemHealth: jest.fn(),
+}));
+
+// Mock chart components
+jest.mock('react-chartjs-2', () => ({
+  Line: (props: any) => <div data-testid="mock-line-chart" data-chart-title={props.options?.plugins?.title?.text}>Line Chart</div>,
+  Bar: (props: any) => <div data-testid="mock-bar-chart" data-chart-title={props.options?.plugins?.title?.text}>Bar Chart</div>,
+  Pie: (props: any) => <div data-testid="mock-pie-chart" data-chart-title={props.options?.plugins?.title?.text}>Pie Chart</div>,
+}));
+
+const mockFetchDashboardStats = fetchDashboardStats as jest.MockedFunction<typeof fetchDashboardStats>;
+const mockFetchSystemHealth = fetchSystemHealth as jest.MockedFunction<typeof fetchSystemHealth>;
+
+// Default mock data structures
+const baseMockSystemHealth: SystemHealth = {
+  api_status: 'OK',
+  db_connection: 'OK',
+};
+
+const baseMockDashboardStats: DashboardStats = {
+  total_users: 0,
+  total_software_titles: 0,
+  recent_activities: [] as RecentActivityItem[],
+  recent_additions: [] as RecentAdditionItem[],
+  popular_downloads: [] as PopularDownloadItem[],
+  documents_per_software: [] as DocumentsPerSoftwareItem[],
+  user_activity_trends: {
+    logins: { daily: [], weekly: [] },
+    uploads: { daily: [], weekly: [] },
+  },
+  total_storage_utilized_bytes: 0,
+  download_trends: {
+    daily: [],
+    weekly: [],
+  },
+  content_health: {
+    missing_descriptions: {
+      documents: { missing: 0, total: 0 },
+      patches: { missing: 0, total: 0 },
+      links: { missing: 0, total: 0 },
+      misc_categories: { missing: 0, total: 0 },
+      software: { missing: 0, total: 0 },
+      misc_files: { missing: 0, total: 0 },
+    },
+    stale_content: {
+      documents: { stale: 0, total: 0 },
+      patches: { stale: 0, total: 0 },
+      links: { stale: 0, total: 0 },
+      misc_files: { stale: 0, total: 0 },
+      versions: { stale: 0, total: 0 },
+      misc_categories: { stale: 0, total: 0 },
+    },
+  },
+};
+
+
+describe('AdminDashboardPage', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockFetchDashboardStats.mockReset();
+    mockFetchSystemHealth.mockReset();
+  });
+
+  const renderPage = () => render(
+    <MemoryRouter>
+      <AdminDashboardPage />
+    </MemoryRouter>
+  );
+
+  test('displays loading indicator while fetching data', () => {
+    mockFetchDashboardStats.mockReturnValue(new Promise(() => {})); // Pending promise
+    mockFetchSystemHealth.mockReturnValue(new Promise(() => {}));   // Pending promise
+    renderPage();
+    expect(screen.getByText(/Loading Dashboard Data.../i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+  });
+
+  test('displays error message if fetching dashboard stats fails', async () => {
+    mockFetchDashboardStats.mockRejectedValueOnce(new Error('Failed to fetch stats'));
+    mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading dashboard statistics: Failed to fetch stats/i)).toBeInTheDocument();
+    });
+  });
+
+  test('displays error message if fetching system health fails', async () => {
+    mockFetchDashboardStats.mockResolvedValueOnce(baseMockDashboardStats);
+    mockFetchSystemHealth.mockRejectedValueOnce(new Error('Failed to fetch health'));
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText(/Error loading system health: Failed to fetch health/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('User Activity Trends Widgets', () => {
+    it('renders Daily Logins chart with data', async () => {
+      const mockStats: DashboardStats = {
+        ...baseMockDashboardStats,
+        user_activity_trends: {
+          ...baseMockDashboardStats.user_activity_trends!,
+          logins: { daily: [{ date: '2023-01-01', count: 5 }], weekly: [] },
+        },
+      };
+      mockFetchDashboardStats.mockResolvedValueOnce(mockStats);
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Daily Logins (Last 7 Days)')).toBeInTheDocument();
+        expect(screen.getByTestId('mock-line-chart')).toBeInTheDocument();
+      });
+    });
+
+    it('renders Daily Uploads chart with data', async () => {
+      const mockStats: DashboardStats = {
+        ...baseMockDashboardStats,
+        user_activity_trends: {
+          ...baseMockDashboardStats.user_activity_trends!,
+          uploads: { daily: [{ date: '2023-01-01', count: 3 }], weekly: [] },
+        },
+      };
+      mockFetchDashboardStats.mockResolvedValueOnce(mockStats);
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Daily Uploads (Last 7 Days)')).toBeInTheDocument();
+        expect(screen.getByTestId('mock-line-chart')).toBeInTheDocument(); // Will find multiple, need to be specific if testing props
+      });
+    });
+    
+    it('shows "No data available" for Daily Logins if data is empty', async () => {
+        mockFetchDashboardStats.mockResolvedValueOnce({
+            ...baseMockDashboardStats,
+            user_activity_trends: { ...baseMockDashboardStats.user_activity_trends!, logins: { daily: [], weekly: [] } },
+        });
+        mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Daily Logins (Last 7 Days)')).toBeInTheDocument();
+            expect(screen.getByText('No login trend data available.')).toBeInTheDocument();
+        });
+    });
+  });
+
+  describe('Storage Utilization Widget', () => {
+    it('displays formatted storage size', async () => {
+      mockFetchDashboardStats.mockResolvedValueOnce({ ...baseMockDashboardStats, total_storage_utilized_bytes: 1234567890 }); // Approx 1.23 GB
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Total Storage Utilized')).toBeInTheDocument();
+        expect(screen.getByText('1.15 GB')).toBeInTheDocument(); // 1234567890 bytes = 1.15 GB
+      });
+    });
+
+    it('displays "0 Bytes" for zero storage', async () => {
+      mockFetchDashboardStats.mockResolvedValueOnce({ ...baseMockDashboardStats, total_storage_utilized_bytes: 0 });
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('0 Bytes')).toBeInTheDocument();
+      });
+    });
+
+    it('displays "N/A" for null storage', async () => {
+      mockFetchDashboardStats.mockResolvedValueOnce({ ...baseMockDashboardStats, total_storage_utilized_bytes: null });
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('N/A')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Download Trends Widget', () => {
+    it('renders Daily Downloads chart with data', async () => {
+      mockFetchDashboardStats.mockResolvedValueOnce({ 
+        ...baseMockDashboardStats, 
+        download_trends: { daily: [{ date: '2023-01-01', count: 10 }], weekly:[] } 
+      });
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Daily Downloads (Last 7 Days)')).toBeInTheDocument();
+        // This will find multiple charts if they are all Line charts.
+        // If distinct testids per chart type are needed, mock should be more specific.
+        expect(screen.getAllByTestId('mock-line-chart').length).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('shows "No data available" for Daily Downloads if data is empty', async () => {
+        mockFetchDashboardStats.mockResolvedValueOnce({
+            ...baseMockDashboardStats,
+            download_trends: { daily: [], weekly: [] },
+        });
+        mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+        renderPage();
+        await waitFor(() => {
+            expect(screen.getByText('Daily Downloads (Last 7 Days)')).toBeInTheDocument();
+            expect(screen.getByText('No download trend data available.')).toBeInTheDocument();
+        });
+    });
+  });
+
+  describe('Content Health Widgets', () => {
+    it('Missing Descriptions: displays correct counts and totals', async () => {
+      mockFetchDashboardStats.mockResolvedValueOnce({ 
+        ...baseMockDashboardStats,
+        content_health: {
+          ...baseMockDashboardStats.content_health!,
+          missing_descriptions: {
+            ...baseMockDashboardStats.content_health!.missing_descriptions,
+            documents: { missing: 2, total: 10 },
+            software: { missing: 1, total: 5 },
+          }
+        }
+      });
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Content: Missing Descriptions')).toBeInTheDocument();
+        expect(screen.getByText(/Documents: 2 \/ 10 \(20.0%\)/i)).toBeInTheDocument();
+        expect(screen.getByText(/Software: 1 \/ 5 \(20.0%\)/i)).toBeInTheDocument();
+      });
+    });
+
+    it('Missing Descriptions: displays "No data available" if section is empty', async () => {
+        mockFetchDashboardStats.mockResolvedValueOnce({ 
+          ...baseMockDashboardStats,
+          content_health: { ...baseMockDashboardStats.content_health!, missing_descriptions: {} as any } // Empty object
+        });
+        mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+        renderPage();
+        await waitFor(() => {
+          expect(screen.getByText('Content: Missing Descriptions')).toBeInTheDocument();
+          expect(screen.getAllByText('No data available.')[0]).toBeInTheDocument(); // First "No data" for missing desc.
+        });
+    });
+
+    it('Stale Content: displays correct counts and totals', async () => {
+      mockFetchDashboardStats.mockResolvedValueOnce({ 
+        ...baseMockDashboardStats,
+        content_health: {
+          ...baseMockDashboardStats.content_health!,
+          stale_content: {
+            ...baseMockDashboardStats.content_health!.stale_content,
+            patches: { stale: 3, total: 15 },
+            versions: { stale: 5, total: 20 },
+          }
+        }
+      });
+      mockFetchSystemHealth.mockResolvedValueOnce(baseMockSystemHealth);
+      renderPage();
+      await waitFor(() => {
+        expect(screen.getByText('Content: Stale Items (Older than 1 year)')).toBeInTheDocument();
+        expect(screen.getByText(/Patches: 3 \/ 15 \(20.0%\)/i)).toBeInTheDocument();
+        expect(screen.getByText(/Versions: 5 \/ 20 \(25.0%\)/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/tests/test_app_stats.py
+++ b/tests/test_app_stats.py
@@ -1,0 +1,367 @@
+import pytest
+import sqlite3
+from datetime import datetime, timedelta, date
+import os
+import sys
+
+# Add the parent directory to sys.path to allow imports from app and database
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Now import from app and database
+# Note: Flask app specific imports might need a test app context if used directly
+from app import get_daily_counts, get_weekly_counts, get_daily_download_counts, get_weekly_download_counts, get_dashboard_stats
+import database # For init_db
+
+# --- Fixtures ---
+@pytest.fixture
+def db_conn():
+    """Fixture to set up an in-memory SQLite database for testing."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    # Initialize schema
+    # Assuming database.init_db takes a connection string/path or can be adapted
+    # For simplicity, we'll directly use the schema from database.SCHEMA_SQL if accessible
+    # or replicate its core parts here if needed.
+    # Let's assume database.init_db can work with a connection object or we adapt.
+    
+    # Temporarily create a dummy DB file for init_db if it insists on a path
+    dummy_db_path = "test_temp_db_for_init.sqlite"
+    database.init_db(dummy_db_path) # This will create tables in the dummy file
+    
+    # Now, we need to get the schema from the dummy file and apply it to in-memory
+    # Or, more simply, if database.SCHEMA_SQL is a string constant:
+    if hasattr(database, 'SCHEMA_SQL'):
+         conn.executescript(database.SCHEMA_SQL)
+    else: # Fallback: Manually define schema or read from schema.sql if available
+        # This is a simplified schema for demonstration if SCHEMA_SQL is not directly accessible
+        # In a real scenario, ensure the full schema is loaded.
+        schema = """
+        CREATE TABLE audit_logs (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER,
+            username TEXT,
+            action_type TEXT NOT NULL,
+            target_table TEXT,
+            target_id INTEGER,
+            details TEXT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE download_log (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            file_id INTEGER NOT NULL,
+            file_type TEXT NOT NULL,
+            user_id INTEGER,
+            ip_address TEXT,
+            download_timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE documents (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            software_id INTEGER,
+            doc_name TEXT,
+            description TEXT,
+            is_external_link BOOLEAN DEFAULT FALSE,
+            file_size INTEGER,
+            stored_filename TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE patches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            version_id INTEGER,
+            patch_name TEXT,
+            description TEXT,
+            is_external_link BOOLEAN DEFAULT FALSE,
+            file_size INTEGER,
+            stored_filename TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE links (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            software_id INTEGER,
+            version_id INTEGER,
+            title TEXT,
+            description TEXT,
+            is_external_link BOOLEAN DEFAULT FALSE,
+            file_size INTEGER,
+            stored_filename TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE misc_files (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            misc_category_id INTEGER,
+            user_provided_title TEXT,
+            user_provided_description TEXT,
+            file_size INTEGER,
+            stored_filename TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE misc_categories (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            description TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE software (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT UNIQUE NOT NULL,
+            description TEXT,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP -- Assuming for staleness, though not typical
+        );
+        CREATE TABLE versions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            software_id INTEGER NOT NULL,
+            version_number TEXT NOT NULL,
+            updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE users ( id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT ); -- Minimal for stats
+        """
+        conn.executescript(schema)
+    conn.commit()
+    
+    yield conn # Provide the connection to the test
+    
+    conn.close()
+    if os.path.exists(dummy_db_path):
+        os.remove(dummy_db_path)
+
+
+# --- Helper to insert audit logs ---
+def insert_audit_log(db, action_type, timestamp_str, username="testuser", user_id=1):
+    dt_obj = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+    db.execute(
+        "INSERT INTO audit_logs (user_id, username, action_type, timestamp) VALUES (?, ?, ?, ?)",
+        (user_id, username, action_type, dt_obj)
+    )
+    db.commit()
+
+# --- Helper to insert download logs ---
+def insert_download_log(db, timestamp_str, file_id=1, file_type="document", user_id=1):
+    dt_obj = datetime.strptime(timestamp_str, "%Y-%m-%d %H:%M:%S")
+    db.execute(
+        "INSERT INTO download_log (file_id, file_type, user_id, download_timestamp) VALUES (?, ?, ?, ?)",
+        (file_id, file_type, user_id, dt_obj)
+    )
+    db.commit()
+
+# --- Tests for User Activity Trends ---
+upload_action_types = [
+    'CREATE_DOCUMENT_FILE', 'CREATE_PATCH_FILE', 'CREATE_LINK_FILE', 'CREATE_MISC_FILE',
+    'UPDATE_DOCUMENT_FILE', 'UPDATE_PATCH_FILE', 'UPDATE_LINK_FILE', 'UPDATE_MISC_FILE_UPLOAD'
+]
+
+def test_get_daily_counts_empty(db_conn):
+    counts = get_daily_counts(db_conn, ['USER_LOGIN'], days=7)
+    assert len(counts) == 7
+    for item in counts:
+        assert item['count'] == 0
+        assert datetime.strptime(item['date'], "%Y-%m-%d") # Check date format
+
+def test_get_weekly_counts_empty(db_conn):
+    counts = get_weekly_counts(db_conn, ['USER_LOGIN'], weeks=4)
+    assert len(counts) == 4
+    for item in counts:
+        assert item['count'] == 0
+        assert datetime.strptime(item['week_start_date'], "%Y-%m-%d")
+
+def test_get_daily_counts_logins_with_data(db_conn):
+    today_str = date.today().strftime("%Y-%m-%d")
+    yesterday_str = (date.today() - timedelta(days=1)).strftime("%Y-%m-%d")
+    
+    insert_audit_log(db_conn, 'USER_LOGIN', f"{today_str} 10:00:00")
+    insert_audit_log(db_conn, 'USER_LOGIN', f"{today_str} 12:00:00")
+    insert_audit_log(db_conn, 'USER_LOGIN', f"{yesterday_str} 20:00:00")
+    insert_audit_log(db_conn, 'SOME_OTHER_ACTION', f"{today_str} 11:00:00")
+
+    counts = get_daily_counts(db_conn, ['USER_LOGIN'], days=7)
+    assert len(counts) == 7
+    
+    today_found = False
+    yesterday_found = False
+    for item in counts:
+        if item['date'] == today_str:
+            assert item['count'] == 2
+            today_found = True
+        elif item['date'] == yesterday_str:
+            assert item['count'] == 1
+            yesterday_found = True
+        else:
+            assert item['count'] == 0 # Other days should be 0
+    assert today_found
+    assert yesterday_found
+
+def test_get_weekly_counts_uploads_with_data(db_conn):
+    # Get current week's Sunday and last week's Sunday
+    today = date.today()
+    current_week_sunday_obj = today - timedelta(days=(today.weekday() + 1) % 7)
+    last_week_sunday_obj = current_week_sunday_obj - timedelta(days=7)
+    
+    current_week_sunday = current_week_sunday_obj.strftime("%Y-%m-%d")
+    last_week_sunday = last_week_sunday_obj.strftime("%Y-%m-%d")
+
+    # One upload this week (e.g., Monday of current week)
+    insert_audit_log(db_conn, 'CREATE_DOCUMENT_FILE', (current_week_sunday_obj + timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S"))
+    # Two uploads last week
+    insert_audit_log(db_conn, 'CREATE_PATCH_FILE', (last_week_sunday_obj + timedelta(days=2)).strftime("%Y-%m-%d %H:%M:%S"))
+    insert_audit_log(db_conn, 'UPDATE_MISC_FILE_UPLOAD', (last_week_sunday_obj + timedelta(days=3)).strftime("%Y-%m-%d %H:%M:%S"))
+
+    counts = get_weekly_counts(db_conn, upload_action_types, weeks=4)
+    assert len(counts) == 4
+
+    current_week_found = False
+    last_week_found = False
+    for item in counts:
+        if item['week_start_date'] == current_week_sunday:
+            assert item['count'] == 1
+            current_week_found = True
+        elif item['week_start_date'] == last_week_sunday:
+            assert item['count'] == 2
+            last_week_found = True
+        else:
+            assert item['count'] == 0
+    assert current_week_found
+    assert last_week_found
+
+
+# --- Tests for Download Trends ---
+def test_get_daily_download_counts_empty(db_conn):
+    counts = get_daily_download_counts(db_conn, days=7)
+    assert len(counts) == 7
+    for item in counts:
+        assert item['count'] == 0
+
+def test_get_weekly_download_counts_empty(db_conn):
+    counts = get_weekly_download_counts(db_conn, weeks=4)
+    assert len(counts) == 4
+    for item in counts:
+        assert item['count'] == 0
+
+def test_get_daily_download_counts_with_data(db_conn):
+    today_str = date.today().strftime("%Y-%m-%d")
+    two_days_ago_str = (date.today() - timedelta(days=2)).strftime("%Y-%m-%d")
+    insert_download_log(db_conn, f"{today_str} 09:00:00")
+    insert_download_log(db_conn, f"{two_days_ago_str} 15:00:00")
+    insert_download_log(db_conn, f"{two_days_ago_str} 16:00:00")
+
+    counts = get_daily_download_counts(db_conn, days=7)
+    today_found = False
+    two_days_ago_found = False
+    for item in counts:
+        if item['date'] == today_str:
+            assert item['count'] == 1
+            today_found = True
+        elif item['date'] == two_days_ago_str:
+            assert item['count'] == 2
+            two_days_ago_found = True
+        else:
+            assert item['count'] == 0
+    assert today_found
+    assert two_days_ago_found
+
+# --- Mock Flask App Context for get_dashboard_stats ---
+@pytest.fixture
+def app_context(db_conn):
+    # Basic Flask app for context, not running a server
+    from flask import Flask, g
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    
+    with app.app_context():
+        g.db = db_conn # Manually set the db connection on g
+        yield app
+
+# --- Tests for Storage Utilization (indirectly via get_dashboard_stats) ---
+def test_storage_utilization_empty(app_context, db_conn):
+    # db_conn is already empty from its fixture
+    with app_context.test_request_context(): # Required if get_dashboard_stats uses request context
+        stats = get_dashboard_stats().get_json()
+    assert stats['total_storage_utilized_bytes'] == 0
+
+def test_storage_utilization_with_data(app_context, db_conn):
+    db_conn.execute("INSERT INTO documents (doc_name, file_size, is_external_link, stored_filename) VALUES (?, ?, ?, ?)", ("doc1.pdf", 1000, False, "file1.pdf"))
+    db_conn.execute("INSERT INTO documents (doc_name, file_size, is_external_link) VALUES (?, ?, ?)", ("doc2_ext.pdf", 2000, True)) # External
+    db_conn.execute("INSERT INTO patches (patch_name, file_size, is_external_link, stored_filename) VALUES (?, ?, ?, ?)", ("patch1.zip", 3000, False, "file2.zip"))
+    db_conn.execute("INSERT INTO links (title, file_size, is_external_link, stored_filename) VALUES (?, ?, ?, ?)", ("link_file.txt", 500, False, "file3.txt"))
+    db_conn.execute("INSERT INTO misc_files (user_provided_title, file_size, stored_filename) VALUES (?, ?, ?)", ("misc1.dat", 1500, "file4.dat"))
+    db_conn.execute("INSERT INTO documents (doc_name, file_size, is_external_link, stored_filename) VALUES (?, ?, ?, ?)", ("doc3.pdf", None, False, "file5.pdf")) # Null size
+    db_conn.commit()
+
+    with app_context.test_request_context():
+        stats = get_dashboard_stats().get_json()
+    assert stats['total_storage_utilized_bytes'] == 1000 + 3000 + 500 + 1500 # 6000
+
+# --- Tests for Content Health (indirectly via get_dashboard_stats) ---
+def test_content_health_missing_descriptions_all_ok(app_context, db_conn):
+    db_conn.execute("INSERT INTO documents (id, doc_name, description) VALUES (1, 'D1', 'Desc D1')")
+    db_conn.execute("INSERT INTO patches (id, patch_name, description) VALUES (1, 'P1', 'Desc P1')")
+    db_conn.commit()
+    
+    with app_context.test_request_context():
+        stats = get_dashboard_stats().get_json()
+    
+    assert stats['content_health']['missing_descriptions']['documents']['missing'] == 0
+    assert stats['content_health']['missing_descriptions']['documents']['total'] == 1
+    assert stats['content_health']['missing_descriptions']['patches']['missing'] == 0
+    assert stats['content_health']['missing_descriptions']['patches']['total'] == 1
+    # ... test other types if populated
+
+def test_content_health_missing_descriptions_some_missing(app_context, db_conn):
+    db_conn.execute("INSERT INTO documents (id, doc_name, description) VALUES (1, 'D1', 'Desc D1')")
+    db_conn.execute("INSERT INTO documents (id, doc_name, description) VALUES (2, 'D2', NULL)")
+    db_conn.execute("INSERT INTO documents (id, doc_name, description) VALUES (3, 'D3', '')")
+    db_conn.execute("INSERT INTO software (id, name, description) VALUES (1, 'S1', NULL)")
+    db_conn.commit()
+
+    with app_context.test_request_context():
+        stats = get_dashboard_stats().get_json()
+        
+    assert stats['content_health']['missing_descriptions']['documents']['missing'] == 2
+    assert stats['content_health']['missing_descriptions']['documents']['total'] == 3
+    assert stats['content_health']['missing_descriptions']['software']['missing'] == 1
+    assert stats['content_health']['missing_descriptions']['software']['total'] == 1
+
+
+def test_content_health_stale_content_all_fresh(app_context, db_conn):
+    # All items updated recently (default CURRENT_TIMESTAMP on inserts)
+    db_conn.execute("INSERT INTO documents (id, doc_name) VALUES (1, 'D1')")
+    db_conn.execute("INSERT INTO versions (id, software_id, version_number) VALUES (1, 1, '1.0')") # Needs software_id
+    db_conn.commit()
+
+    with app_context.test_request_context():
+        stats = get_dashboard_stats().get_json()
+        
+    assert stats['content_health']['stale_content']['documents']['stale'] == 0
+    assert stats['content_health']['stale_content']['versions']['stale'] == 0
+
+
+def test_content_health_stale_content_some_stale(app_context, db_conn):
+    one_year_ago_plus_one_day = (datetime.now() - timedelta(days=366)).strftime('%Y-%m-%d %H:%M:%S')
+    two_years_ago = (datetime.now() - timedelta(days=730)).strftime('%Y-%m-%d %H:%M:%S')
+
+    db_conn.execute("INSERT INTO documents (id, doc_name, updated_at) VALUES (1, 'D_stale', ?)", (one_year_ago_plus_one_day,))
+    db_conn.execute("INSERT INTO documents (id, doc_name) VALUES (2, 'D_fresh')") # Uses default CURRENT_TIMESTAMP
+    db_conn.execute("INSERT INTO versions (id, software_id, version_number, updated_at) VALUES (1, 1, 'V_stale', ?)", (two_years_ago,))
+    db_conn.commit()
+
+    with app_context.test_request_context():
+        stats = get_dashboard_stats().get_json()
+        
+    assert stats['content_health']['stale_content']['documents']['stale'] == 1
+    assert stats['content_health']['stale_content']['documents']['total'] == 2
+    assert stats['content_health']['stale_content']['versions']['stale'] == 1
+    assert stats['content_health']['stale_content']['versions']['total'] == 1
+    
+    # Ensure misc_categories is present even if empty
+    assert 'misc_categories' in stats['content_health']['stale_content']
+    assert stats['content_health']['stale_content']['misc_categories']['stale'] == 0
+    assert stats['content_health']['stale_content']['misc_categories']['total'] == 0
+
+    # Ensure software is NOT in stale_content (as it has no updated_at in this schema for staleness)
+    assert 'software' not in stats['content_health']['stale_content']
+
+# Note: The flask app context setup for get_dashboard_stats is basic.
+# If get_dashboard_stats or its internal calls rely on specific Flask features
+# like request object for args, or specific app.config values not set here,
+# those tests might need a more elaborate app fixture.
+# For now, assuming g.db is the primary dependency that's correctly mocked.
+# Also, the jwt_required decorator is not handled here; if tests fail due to it,
+# the test client or request context might need to simulate an authenticated request.
+# For this task, focus is on the data aggregation logic.


### PR DESCRIPTION
This commit introduces several new statistical widgets to the admin dashboard, providing more granular insights into user activity, storage utilization, download trends, and content health.

Backend Changes (app.py):
- Added helper functions to aggregate data from `audit_logs` for:
  - Daily and weekly user login trends.
  - Daily and weekly content upload trends.
- Implemented calculation for total storage utilized by summing `file_size` from `documents`, `patches`, `links`, and `misc_files`.
- Added helper functions to aggregate data from `download_log` for:
  - Daily and weekly download trends.
- Implemented logic to calculate content health indicators:
  - Items missing descriptions (per content type).
  - Stale content (items not updated in over a year, per content type).
- All new statistics are exposed via the existing `/api/admin/dashboard-stats` endpoint.

Frontend Changes (AdminDashboardPage.tsx & services/api.ts):
- Updated the `DashboardStats` interface in `services/api.ts` to include the new data structures for all added statistics.
- Added new Line chart widgets to display:
  - Daily user login trends.
  - Daily user upload trends.
  - Daily download trends.
- Added a summary card widget to display total storage utilization in a human-readable format.
- Added new list-based widgets to display content health indicators for:
  - Items missing descriptions (count, total, percentage per type).
  - Stale content items (count, total, percentage per type).
- Adjusted the overall layout of the admin dashboard to accommodate the new widgets, ensuring responsiveness.

Testing:
- Added backend unit tests for the new data aggregation functions in `app.py` using pytest and an in-memory SQLite database.
- Added frontend unit tests for the new `AdminDashboardPage.tsx` widgets covering loading, error states, and rendering of statistics with mocked API responses and chart components.