### PR TITLE
feat: Implement bulk actions and UI enhancements

### DIFF
--- a/frontend/src/views/GlobalLoginPage.tsx
+++ b/frontend/src/views/GlobalLoginPage.tsx
@@ -29,7 +29,7 @@ const GlobalLoginPage: React.FC = () => {
       alignItems: 'center', 
       justifyContent: 'center', 
       minHeight: '100vh',
-      backgroundColor: '#f0f2f5' // A slightly different background for distinction
+      backgroundColor: 'background.default' // Use theme's default background
     }}>
       <Box
         sx={{
@@ -38,12 +38,12 @@ const GlobalLoginPage: React.FC = () => {
           flexDirection: 'column',
           alignItems: 'center',
           padding: 3,
-          backgroundColor: 'white',
+          backgroundColor: 'background.paper', // Use theme's paper background for the card
           borderRadius: 2,
-          boxShadow: '0 3px 10px rgb(0 0 0 / 0.2)'
+          boxShadow: '0 3px 10px rgb(0 0 0 / 0.2)' // Shadow can remain, usually fine for both modes
         }}
       >
-        <Typography component="h1" variant="h5" sx={{ mb: 2 }}>
+        <Typography component="h1" variant="h5" sx={{ mb: 2, color: 'text.primary' }}> 
           Site Access Control
         </Typography>
         <Typography component="p" sx={{ mb: 2, textAlign: 'center', color: 'text.secondary' }}>
@@ -72,7 +72,8 @@ const GlobalLoginPage: React.FC = () => {
             type="submit"
             fullWidth
             variant="contained"
-            sx={{ mt: 3, mb: 2, backgroundColor: '#1976d2' }} // Standard blue
+            color="primary" // Use theme's primary color
+            sx={{ mt: 3, mb: 2 }} 
           >
             Unlock
           </Button>

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -2,20 +2,11 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import {
-  fetchLinks,
-  fetchSoftware,
-  fetchVersionsForSoftware,
-  deleteAdminLink,
-  PaginatedLinksResponse,
-  addFavoriteApi,
-  removeFavoriteApi,
-  FavoriteItemType
+  fetchLinks, fetchSoftware, fetchVersionsForSoftware, deleteAdminLink,
+  PaginatedLinksResponse, addFavoriteApi, removeFavoriteApi, FavoriteItemType,
+  bulkDeleteItems, bulkDownloadItems, bulkMoveItems, BulkItemType, SoftwareVersion
 } from '../services/api';
-import {
-  Link as LinkType,
-  Software,
-  SoftwareVersion
-} from '../types';
+import { Link as LinkType, Software } from '../types';
 import DataTable, { ColumnDef } from '../components/DataTable';
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState'; 
@@ -23,21 +14,22 @@ import ErrorState from '../components/ErrorState';
 import { useAuth } from '../context/AuthContext';
 import AdminLinkEntryForm from '../components/admin/AdminLinkEntryForm';
 import ConfirmationModal from '../components/shared/ConfirmationModal';
-import { PlusCircle, Edit3, Trash2, ExternalLink, Star, Filter, ChevronUp, Link as LinkIcon } from 'lucide-react'; // Added Filter, ChevronUp, LinkIcon
-import { Box, Typography } from '@mui/material'; // Added Box and Typography
+import Modal from '../components/shared/Modal';
+import { PlusCircle, Edit3, Trash2, ExternalLink, Star, Filter, ChevronUp, Link as LinkIconLucide, Download, Move, AlertTriangle } from 'lucide-react';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils'; 
 
 interface OutletContextType {
   searchTerm: string;
+  setSearchTerm: (term: string) => void;
 }
 
 const LinksView: React.FC = () => {
-  const { searchTerm } = useOutletContext<OutletContextType>();
+  const { searchTerm, setSearchTerm } = useOutletContext<OutletContextType>();
   const { isAuthenticated, role } = useAuth();
 
   const [links, setLinks] = useState<LinkType[]>([]);
   const [softwareList, setSoftwareList] = useState<Software[]>([]);
-  const [versionList, setVersionList] = useState<SoftwareVersion[]>([]);
+  const [versionList, setVersionList] = useState<SoftwareVersion[]>([]); // For main page filter
 
   const [activeSoftwareId, setActiveSoftwareId] = useState<number | null>(null);
   const [activeVersionId, setActiveVersionId] = useState<number | null>(null);
@@ -47,302 +39,339 @@ const LinksView: React.FC = () => {
   const [createdToFilter, setCreatedToFilter] = useState<string>('');
   
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [itemsPerPage, setItemsPerPage] = useState<number>(10);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(15); // Default
   const [totalPages, setTotalPages] = useState<number>(0);
   const [totalLinks, setTotalLinks] = useState<number>(0);
 
   const [sortBy, setSortBy] = useState<string>('title');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
   const [error, setError] = useState<string | null>(null); 
-  const [isInitialLoad, setIsInitialLoad] = useState(true); 
 
   const [showAddOrEditForm, setShowAddOrEditForm] = useState(false);
   const [editingLink, setEditingLink] = useState<LinkType | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [linkToDelete, setLinkToDelete] = useState<LinkType | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [isProcessingSingleItem, setIsProcessingSingleItem] = useState(false);
 
   const [favoritedItems, setFavoritedItems] = useState<Map<number, { favoriteId: number | undefined }>>(new Map());
-  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false); // State for filter toggle
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false);
 
-  const loadLinks = useCallback(async () => {
-    setIsLoading(true);
-    if (isInitialLoad) {
-      setError(null); 
-    }
+  // Bulk Action States
+  const [selectedLinkIds, setSelectedLinkIds] = useState<Set<number>>(new Set());
+  const [isDeletingSelected, setIsDeletingSelected] = useState<boolean>(false);
+  const [isDownloadingSelected, setIsDownloadingSelected] = useState<boolean>(false);
+  const [isMovingSelected, setIsMovingSelected] = useState<boolean>(false);
+  const [showBulkMoveModal, setShowBulkMoveModal] = useState<boolean>(false);
+  const [modalSelectedSoftwareId, setModalSelectedSoftwareId] = useState<number | null>(null);
+  const [modalVersionsList, setModalVersionsList] = useState<SoftwareVersion[]>([]);
+  const [modalSelectedVersionId, setModalSelectedVersionId] = useState<number | null | undefined>(undefined);
+  const [showBulkDeleteConfirmModal, setShowBulkDeleteConfirmModal] = useState<boolean>(false);
+  const [isLoadingModalVersions, setIsLoadingModalVersions] = useState<boolean>(false);
+  
+  const filtersAreActive = useMemo(() => {
+    return activeSoftwareId !== null || activeVersionId !== null || linkTypeFilter !== '' || createdFromFilter !== '' || createdToFilter !== '' || searchTerm !== '';
+  }, [activeSoftwareId, activeVersionId, linkTypeFilter, createdFromFilter, createdToFilter, searchTerm]);
+
+  const handleClearAllFiltersAndSearch = useCallback(() => {
+    setActiveSoftwareId(null); setActiveVersionId(null);
+    setLinkTypeFilter(''); setCreatedFromFilter(''); setCreatedToFilter('');
+    if (setSearchTerm) setSearchTerm('');
+    setCurrentPage(1); // Reset to page 1
+    // fetchAndSetLinks(1, true) will be called by useEffect
+  }, [setSearchTerm]);
+  
+  const fetchAndSetLinks = useCallback(async (pageToLoad: number, isNewQuery: boolean = false) => {
+    if (isNewQuery) setIsLoadingInitial(true);
+    setError(null); 
 
     try {
       const response: PaginatedLinksResponse = await fetchLinks(
         activeSoftwareId || undefined, activeVersionId || undefined,
-        currentPage, itemsPerPage, sortBy, sortOrder,
+        pageToLoad, itemsPerPage, sortBy, sortOrder,
         linkTypeFilter || undefined, createdFromFilter || undefined, createdToFilter || undefined
       );
-
       setLinks(response.links);
       setTotalPages(response.total_pages);
       setTotalLinks(response.total_links);
       setCurrentPage(response.page);
       setItemsPerPage(response.per_page);
 
-      const newFavoritedItems = new Map<number, { favoriteId: number | undefined }>();
-      if (isAuthenticated && response.links && response.links.length > 0) {
-        for (const link of response.links) {
-          if (link.favorite_id) { newFavoritedItems.set(link.id, { favoriteId: link.favorite_id }); } 
-          else { newFavoritedItems.set(link.id, { favoriteId: undefined }); }
-        }
-      }
-      setFavoritedItems(newFavoritedItems);
-
-      if (isInitialLoad) {
-        setIsInitialLoad(false); 
-      }
+      const newFavs = new Map<number, { favoriteId: number | undefined }>();
+      if (isAuthenticated && response.links) response.links.forEach(l => newFavs.set(l.id, { favoriteId: l.favorite_id }));
+      setFavoritedItems(newFavs);
     } catch (err: any) {
-      console.error("Failed to load links:", err);
-      const errorMessage = err.response?.data?.msg || err.message || 'Failed to fetch links.';
-      if (isInitialLoad) {
-        setError(errorMessage); setLinks([]); setTotalPages(0); setTotalLinks(0); setFavoritedItems(new Map());
-      } else {
-        showErrorToast(errorMessage); 
-      }
+      const msg = err.response?.data?.msg || err.message || 'Failed to fetch links.';
+      if (isNewQuery) { setError(msg); setLinks([]); setTotalPages(0); setTotalLinks(0); }
+      else showErrorToast(msg); 
     } finally {
-      setIsLoading(false);
+      if (isNewQuery) setIsLoadingInitial(false);
     }
-  }, [
-    activeSoftwareId, activeVersionId, currentPage, itemsPerPage, sortBy, sortOrder,
-    linkTypeFilter, createdFromFilter, createdToFilter,
-    isAuthenticated, isInitialLoad
-  ]);
+  }, [activeSoftwareId, activeVersionId, itemsPerPage, sortBy, sortOrder, linkTypeFilter, createdFromFilter, createdToFilter, isAuthenticated]);
 
-  useEffect(() => { if (!isAuthenticated) { setFavoritedItems(new Map()); } }, [isAuthenticated]);
+  useEffect(() => { if (isAuthenticated) fetchSoftware().then(setSoftwareList).catch(err => showErrorToast("Failed to load software list.")); else setSoftwareList([]); }, [isAuthenticated]);
+  
+  useEffect(() => {
+    if (isAuthenticated) fetchAndSetLinks(1, true);
+    else { setLinks([]); setIsLoadingInitial(false); }
+  }, [isAuthenticated, activeSoftwareId, activeVersionId, sortBy, sortOrder, linkTypeFilter, createdFromFilter, createdToFilter, fetchAndSetLinks]);
+
+  useEffect(() => { setSelectedLinkIds(new Set()); }, [activeSoftwareId, activeVersionId, sortBy, sortOrder, linkTypeFilter, createdFromFilter, createdToFilter, searchTerm, currentPage]);
 
   useEffect(() => {
-    const loadSoftwareAndInitialLinks = async () => {
-      try {
-        const softwareData = await fetchSoftware();
-        setSoftwareList(softwareData);
-      } catch (err: any) {
-        console.error("Failed to load software for filters", err);
-        showErrorToast(err.response?.data?.msg || "Failed to load software filters.");
-      }
-    };
-    loadSoftwareAndInitialLinks();
-  }, []);
-  
-  useEffect(() => { loadLinks(); }, [loadLinks]);
+    if (activeSoftwareId) fetchVersionsForSoftware(activeSoftwareId).then(setVersionList).catch(() => { showErrorToast("Failed to load versions for filter."); setVersionList([]); });
+    else setVersionList([]);
+  }, [activeSoftwareId]);
 
   useEffect(() => {
-    if (activeSoftwareId) {
-      const loadVersions = async () => {
-        try {
-          const versionsData = await fetchVersionsForSoftware(activeSoftwareId);
-          setVersionList(versionsData);
-        } catch (err: any) {
-          console.error("Failed to load versions for software:", activeSoftwareId, err);
-          showErrorToast(err.response?.data?.msg || `Failed to load versions for ${softwareList.find(s => s.id === activeSoftwareId)?.name || 'software'}.`);
-          setVersionList([]);
-        }
-      };
-      loadVersions();
-    } else {
-      setVersionList([]);
-    }
-  }, [activeSoftwareId, softwareList]);
+    if (modalSelectedSoftwareId) {
+      setIsLoadingModalVersions(true);
+      fetchVersionsForSoftware(modalSelectedSoftwareId).then(setModalVersionsList).catch(() => showErrorToast("Failed to load versions for move.")).finally(() => setIsLoadingModalVersions(false));
+    } else setModalVersionsList([]);
+  }, [modalSelectedSoftwareId]);
 
-  const handleSoftwareFilterChange = (softwareId: number | null) => { setActiveSoftwareId(softwareId); setActiveVersionId(null); setCurrentPage(1); setIsInitialLoad(true);};
-  const handleVersionFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const versionId = event.target.value ? parseInt(event.target.value, 10) : null;
-    setActiveVersionId(versionId); setCurrentPage(1); setIsInitialLoad(true);
-  };
-  const handlePageChange = (newPage: number) => { setCurrentPage(newPage); };
-  const handleSort = (columnKey: string) => {
-    if (sortBy === columnKey) { setSortOrder(prevOrder => (prevOrder === 'asc' ? 'desc' : 'asc')); } 
-    else { setSortBy(columnKey); setSortOrder('asc'); }
-    setCurrentPage(1); setIsInitialLoad(true);
-  };
-  const handleApplyAdvancedFilters = () => { setCurrentPage(1); setIsInitialLoad(true);};
-  const handleClearAdvancedFilters = () => {
-    setLinkTypeFilter(''); setCreatedFromFilter(''); setCreatedToFilter('');
-    setCurrentPage(1); setIsInitialLoad(true);
-  };
-  
-  const handleOperationSuccess = (message: string) => {
-    setShowAddOrEditForm(false); setEditingLink(null);
-    setFeedbackMessage(message); 
-    loadLinks();
-  };
-  
-  const openAddForm = () => { setEditingLink(null); setShowAddOrEditForm(true); setFeedbackMessage(null); };
-  const openEditForm = (link: LinkType) => { setEditingLink(link); setShowAddOrEditForm(true); setFeedbackMessage(null); };
+  const handleSoftwareFilterChange = (id: number | null) => { setActiveSoftwareId(id); setActiveVersionId(null); setCurrentPage(1); };
+  const handleVersionFilterChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setActiveVersionId(e.target.value ? parseInt(e.target.value) : null); setCurrentPage(1); };
+  const handlePageChange = (newPage: number) => { setCurrentPage(newPage); fetchAndSetLinks(newPage, true); }; // isNewQuery = true for page changes
+  const handleSort = (key: string) => { setSortBy(key); setSortOrder(prev => (sortBy === key && prev === 'asc' ? 'desc' : 'asc')); setCurrentPage(1); };
+  const handleApplyAdvancedFilters = () => { setCurrentPage(1); fetchAndSetLinks(1, true);};
+
+  const handleOperationSuccess = (message: string) => { setShowAddOrEditForm(false); setEditingLink(null); showSuccessToast(message); fetchAndSetLinks(1, true); };
+  const openAddForm = () => { setEditingLink(null); setShowAddOrEditForm(true); };
+  const openEditForm = (link: LinkType) => { setEditingLink(link); setShowAddOrEditForm(true); };
   const closeAdminForm = () => { setEditingLink(null); setShowAddOrEditForm(false); };
-  const openDeleteConfirm = (link: LinkType) => { setLinkToDelete(link); setShowDeleteConfirm(true); setFeedbackMessage(null); };
+  const openDeleteConfirm = (link: LinkType) => { setLinkToDelete(link); setShowDeleteConfirm(true); };
   const closeDeleteConfirm = () => { setLinkToDelete(null); setShowDeleteConfirm(false); };
 
-  const handleDeleteConfirm = async () => {
+  const handleDeleteLinkConfirm = async () => {
     if (!linkToDelete) return;
-    setIsDeleting(true);
+    setIsProcessingSingleItem(true);
     try {
       await deleteAdminLink(linkToDelete.id);
-      showSuccessToast(`Link "${linkToDelete.title}" deleted successfully.`);
-      closeDeleteConfirm();
-      if (links.length === 1 && currentPage > 1) { setCurrentPage(currentPage - 1); } 
-      else { loadLinks(); }
-    } catch (err: any) {
-      showErrorToast(err.response?.data?.msg || err.message || "Failed to delete link.");
-      closeDeleteConfirm();
-    } finally {
-      setIsDeleting(false);
-    }
+      showSuccessToast(`Link "${linkToDelete.title}" deleted.`);
+      closeDeleteConfirm(); fetchAndSetLinks(1, true);
+    } catch (err: any) { showErrorToast(err.message || "Delete failed."); closeDeleteConfirm(); }
+    finally { setIsProcessingSingleItem(false); }
   };
 
   const filteredLinksBySearch = useMemo(() => {
     if (!searchTerm) return links;
-    const lowerSearchTerm = searchTerm.toLowerCase();
-    return links.filter(link =>
-      link.title.toLowerCase().includes(lowerSearchTerm) ||
-      (link.description || '').toLowerCase().includes(lowerSearchTerm) ||
-      (link.software_name || '').toLowerCase().includes(lowerSearchTerm) ||
-      (link.version_number || '').toLowerCase().includes(lowerSearchTerm)
-    );
+    const lower = searchTerm.toLowerCase();
+    return links.filter(l => l.title.toLowerCase().includes(lower) || (l.description||'').toLowerCase().includes(lower) || (l.software_name||'').toLowerCase().includes(lower) || (l.version_number||'').toLowerCase().includes(lower));
   }, [links, searchTerm]);
 
+  const handleSelectItem = (id: number, isSelected: boolean) => setSelectedLinkIds(prev => { const n = new Set(prev); if (isSelected) n.add(id); else n.delete(id); return n; });
+  const handleSelectAllItems = (isSelected: boolean) => { const n = new Set<number>(); if (isSelected) filteredLinksBySearch.forEach(l => n.add(l.id)); setSelectedLinkIds(n); };
+
+  const handleBulkDeleteLinksClick = () => { if (selectedLinkIds.size === 0) { showErrorToast("No items selected."); return; } setShowBulkDeleteConfirmModal(true); };
+  const confirmBulkDeleteLinks = async () => {
+    setShowBulkDeleteConfirmModal(false); setIsDeletingSelected(true);
+    try {
+      const res = await bulkDeleteItems(Array.from(selectedLinkIds), 'link');
+      showSuccessToast(res.msg || `${res.deleted_count} link(s) deleted.`);
+      setSelectedLinkIds(new Set()); fetchAndSetLinks(1, true);
+    } catch (e: any) { showErrorToast(e.message || "Bulk delete failed."); }
+    finally { setIsDeletingSelected(false); }
+  };
+
+  const downloadableSelectedCount = useMemo(() => {
+    return links.filter(link => selectedLinkIds.has(link.id) && !link.is_external_link && link.stored_filename).length;
+  }, [links, selectedLinkIds]);
+
+  const handleBulkDownloadLinks = async () => {
+    if (selectedLinkIds.size === 0) { showErrorToast("No items selected."); return; }
+    const downloadableLinks = links.filter(link => selectedLinkIds.has(link.id) && !link.is_external_link && link.stored_filename);
+    if (downloadableLinks.length === 0) { showErrorToast("No downloadable files among selected links. External links or links without files cannot be bulk downloaded."); return; }
+    
+    const downloadableLinkIds = downloadableLinks.map(link => link.id);
+    if (downloadableLinkIds.length < selectedLinkIds.size) {
+      showSuccessToast(`Starting download for ${downloadableLinkIds.length} file-based links. External links were excluded.`);
+    }
+
+    setIsDownloadingSelected(true);
+    try {
+      const blob = await bulkDownloadItems(downloadableLinkIds, 'link');
+      const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url;
+      const ts = new Date().toISOString().replace(/:/g, '-'); a.download = `bulk_download_links_${ts}.zip`;
+      document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(url);
+      if (downloadableLinkIds.length === selectedLinkIds.size) showSuccessToast('Download started.'); 
+    } catch (e: any) { showErrorToast(e.message || "Bulk download failed."); }
+    finally { setIsDownloadingSelected(false); }
+  };
+  
+  const handleOpenBulkMoveLinksModal = () => {
+    if (selectedLinkIds.size === 0) { showErrorToast("No items selected."); return; }
+    if (softwareList.length === 0) { showErrorToast("Software list unavailable."); return; }
+    setModalSelectedSoftwareId(null); setModalSelectedVersionId(undefined); setShowBulkMoveModal(true);
+  };
+
+  const handleConfirmBulkMoveLinks = async () => {
+    if (!modalSelectedSoftwareId) { showErrorToast("Select target software."); return; }
+    setShowBulkMoveModal(false); setIsMovingSelected(true);
+    const targetMetadata: {target_software_id: number, target_version_id?: number | null} = { target_software_id: modalSelectedSoftwareId };
+    if (modalSelectedVersionId !== undefined) { 
+      targetMetadata.target_version_id = modalSelectedVersionId;
+    }
+    try {
+      const res = await bulkMoveItems(Array.from(selectedLinkIds), 'link', targetMetadata);
+      showSuccessToast(res.msg || `${res.moved_count} link(s) moved.`);
+      setSelectedLinkIds(new Set()); fetchAndSetLinks(1, true);
+    } catch (e: any) { showErrorToast(e.message || "Bulk move failed."); }
+    finally { setIsMovingSelected(false); setModalSelectedSoftwareId(null); setModalSelectedVersionId(undefined); }
+  };
+  
   const columns: ColumnDef<LinkType>[] = [
-    { key: 'title', header: 'Title', sortable: true },
-    { key: 'software_name', header: 'Software', sortable: true },
-    { key: 'version_name', header: 'Version', sortable: true },
-    { key: 'description', header: 'Description', render: (link: LinkType) => ( <span className="text-sm text-gray-600 block max-w-xs truncate" title={link.description || ''}>{link.description || '-'}</span> ) },
-    { key: 'url', header: 'URL', render: (link: LinkType) => ( <a href={link.url} target={link.is_external_link || !link.url?.startsWith('/') ? "_blank" : "_self"} rel="noopener noreferrer" className="flex items-center text-blue-600 hover:text-blue-800" onClick={(e) => e.stopPropagation()}> {link.url.length > 50 ? `${link.url.substring(0, 50)}...` : link.url} {(link.is_external_link || !link.url?.startsWith('/')) && <ExternalLink size={14} className="ml-1 flex-shrink-0" />} </a> ) },
-    { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (link) => link.uploaded_by_username || 'N/A' },
-    { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (link) => link.updated_by_username || 'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: (link) => link.created_at ? new Date(link.created_at).toLocaleDateString('en-CA') : '-' },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (link) => link.updated_at ? new Date(link.updated_at).toLocaleDateString('en-CA') : '-' },
-    ...(isAuthenticated ? [{
-      key: 'actions' as keyof LinkType | 'actions', header: 'Actions',
-      render: (link: LinkType) => (
-        <div className="flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-          <button onClick={(e) => { e.stopPropagation(); handleFavoriteToggle(link, 'link' as FavoriteItemType);}} className={`p-1 ${favoritedItems.get(link.id)?.favoriteId ? 'text-yellow-500' : 'text-gray-400'} hover:text-yellow-600`} title={favoritedItems.get(link.id)?.favoriteId ? "Remove from Favorites" : "Add to Favorites"}> <Star size={16} className={favoritedItems.get(link.id)?.favoriteId ? "fill-current" : ""} /> </button>
-          {(role === 'admin' || role === 'super_admin') && (
-            <>
-              <button onClick={(e) => { e.stopPropagation(); openEditForm(link);}} className="p-1 text-blue-600 hover:text-blue-800" title="Edit Link"><Edit3 size={16} /></button>
-              <button onClick={(e) => { e.stopPropagation(); openDeleteConfirm(link);}} className="p-1 text-red-600 hover:text-red-800" title="Delete Link"><Trash2 size={16} /></button>
-            </>
-          )}
-        </div>
-      ),
-    }] : [])
+    { key: 'title', header: 'Title', sortable: true }, { key: 'software_name', header: 'Software', sortable: true },
+    { key: 'version_name', header: 'Version', sortable: true, render: l => l.version_number || 'N/A' },
+    { key: 'description', header: 'Description', render: l => <span className="text-sm text-gray-600 block max-w-xs truncate" title={l.description||''}>{l.description||'-'}</span> },
+    { key: 'url', header: 'URL/File', render: (l: LinkType) => ( <a href={l.url} target={l.is_external_link || !l.url?.startsWith('/') ? "_blank" : "_self"} rel="noopener noreferrer" className="flex items-center text-blue-600 hover:text-blue-800" onClick={e=>e.stopPropagation()}> {l.is_external_link ? l.url.length > 40 ? `${l.url.substring(0,37)}...` : l.url : (l.original_filename_ref || l.url.split('/').pop() || 'Uploaded File')} {(l.is_external_link || !l.url?.startsWith('/')) && <ExternalLink size={14} className="ml-1 flex-shrink-0"/>} </a> ) },
+    { key: 'uploaded_by_username', header: 'Added By', sortable: true, render: l => l.uploaded_by_username||'N/A' },
+    { key: 'updated_by_username', header: 'Updated By', sortable: false, render: l => l.updated_by_username||'N/A' },
+    { key: 'created_at', header: 'Created', sortable: true, render: l => l.created_at?new Date(l.created_at).toLocaleDateString('en-CA'):'-' },
+    { key: 'updated_at', header: 'Updated', sortable: true, render: l => l.updated_at?new Date(l.updated_at).toLocaleDateString('en-CA'):'-' },
+    { key: 'actions' as any, header: 'Actions', render: (l: LinkType) => (<div className="flex space-x-1 items-center">{isAuthenticated&&(<button onClick={e=>{e.stopPropagation();handleFavoriteToggle(l,'link')}} className={`p-1 rounded-md ${favoritedItems.get(l.id)?.favoriteId?'text-yellow-500 hover:text-yellow-600':'text-gray-400 hover:text-yellow-500'}`} title={favoritedItems.get(l.id)?.favoriteId?"Remove Favorite":"Add Favorite"}><Star size={16} className={favoritedItems.get(l.id)?.favoriteId?"fill-current":""}/></button>)}{(role==='admin'||role==='super_admin')&&(<> <button onClick={e=>{e.stopPropagation();openEditForm(l)}} className="p-1 text-blue-600 hover:text-blue-800 rounded-md" title="Edit"><Edit3 size={16}/></button> <button onClick={e=>{e.stopPropagation();openDeleteConfirm(l)}} className="p-1 text-red-600 hover:text-red-800 rounded-md" title="Delete"><Trash2 size={16}/></button></>)}</div>)},
   ];
+  
+  const loadLinksCallback = useCallback(() => { fetchAndSetLinks(1, true); }, [fetchAndSetLinks]);
 
   const handleFavoriteToggle = async (item: LinkType, itemType: FavoriteItemType) => {
     if (!isAuthenticated) { showErrorToast("Please log in to manage favorites."); return; }
     const currentStatus = favoritedItems.get(item.id);
     const isCurrentlyFavorited = !!currentStatus?.favoriteId;
-    const tempFavoritedItems = new Map(favoritedItems);
-    if (isCurrentlyFavorited) { tempFavoritedItems.set(item.id, { favoriteId: undefined }); } 
-    else { tempFavoritedItems.set(item.id, { favoriteId: -1 }); }
-    setFavoritedItems(tempFavoritedItems);
-    setFeedbackMessage(null); 
-
+    const tempFavs = new Map(favoritedItems);
+    if (isCurrentlyFavorited) tempFavs.set(item.id, { favoriteId: undefined }); else tempFavs.set(item.id, { favoriteId: -1 });
+    setFavoritedItems(tempFavs);
     try {
       if (isCurrentlyFavorited && typeof currentStatus?.favoriteId === 'number') {
         await removeFavoriteApi(item.id, itemType);
         showSuccessToast(`"${item.title}" removed from favorites.`);
-        setFavoritedItems(prev => { const newMap = new Map(prev); newMap.set(item.id, { favoriteId: undefined }); return newMap; });
+        setFavoritedItems(prev => { const n = new Map(prev); n.set(item.id, { favoriteId: undefined }); return n; });
       } else {
-        const newFavorite = await addFavoriteApi(item.id, itemType);
+        const newFav = await addFavoriteApi(item.id, itemType);
+        setFavoritedItems(prev => { const n = new Map(prev); n.set(item.id, { favoriteId: newFav.id }); return n; });
         showSuccessToast(`"${item.title}" added to favorites.`);
-        setFavoritedItems(prev => { const newMap = new Map(prev); newMap.set(item.id, { favoriteId: newFavorite.id }); return newMap; });
       }
-    } catch (error: any) {
-      showErrorToast(error?.response?.data?.msg || error.message || "Failed to update favorite status.");
-      setFavoritedItems(prev => { 
-        const newMap = new Map(prev);
-        if (isCurrentlyFavorited) { newMap.set(item.id, { favoriteId: currentStatus?.favoriteId });} 
-        else { newMap.set(item.id, { favoriteId: undefined }); }
-        return newMap;
-      });
+    } catch (e: any) {
+      showErrorToast(e?.response?.data?.msg || e.message || "Failed to update favorite.");
+      setFavoritedItems(prev => { const n=new Map(prev); if(isCurrentlyFavorited)n.set(item.id,{favoriteId:currentStatus?.favoriteId}); else n.set(item.id,{favoriteId:undefined}); return n;});
     }
   };
 
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-start sm:items-center mb-6 flex-col sm:flex-row">
-        <div> <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Links</h2> <p className="text-gray-600 mt-1 dark:text-gray-300">Useful links and resources</p> </div>
-        {isAuthenticated && (role === 'admin' || role === 'super_admin') && (
-          <button onClick={showAddOrEditForm && !editingLink ? closeAdminForm : openAddForm} className="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-            <PlusCircle size={18} className="mr-2" /> {showAddOrEditForm && !editingLink ? 'Cancel Add Link' : 'Add New Link'}
+        <div> <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Links</h2> <p className="text-gray-600 mt-1 dark:text-gray-300">Manage and browse useful links and resources.</p> </div>
+        {isAuthenticated && (role === 'admin' || role === 'super_admin') && !editingLink && (
+          <button onClick={showAddOrEditForm ? closeAdminForm : openAddForm} className="mt-4 sm:mt-0 btn-primary">
+            <PlusCircle size={18} className="mr-2" /> {showAddOrEditForm ? 'Cancel' : 'Add New Link'}
           </button>
         )}
       </div>
 
-      {feedbackMessage && <div className="p-3 my-2 bg-green-100 text-green-700 rounded text-sm">{feedbackMessage}</div>}
+      {showAddOrEditForm && (<div className="my-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"><AdminLinkEntryForm linkToEdit={editingLink} onLinkAdded={()=>handleOperationSuccess("Link added.")} onLinkUpdated={()=>handleOperationSuccess("Link updated.")} onCancelEdit={closeAdminForm}/></div>)}
 
-      {showAddOrEditForm && isAuthenticated && (role === 'admin' || role === 'super_admin') && (
-        <div className="my-6 p-4 bg-gray-50 rounded-lg shadow">
-          <AdminLinkEntryForm linkToEdit={editingLink} onLinkAdded={() => handleOperationSuccess('Link added successfully.')} onLinkUpdated={() => handleOperationSuccess('Link updated successfully.')} onCancelEdit={closeAdminForm} />
+      {selectedLinkIds.size > 0 && (
+        <div className="my-4 p-3 bg-gray-100 dark:bg-gray-700 rounded-md shadow-sm border border-gray-200 dark:border-gray-600">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{selectedLinkIds.size} item(s) selected</span>
+            {(role === 'admin' || role === 'super_admin') && (<button onClick={handleBulkDeleteLinksClick} disabled={isDeletingSelected} className="btn-danger-xs flex items-center"><Trash2 size={14} className="mr-1.5"/>Delete</button>)}
+            {isAuthenticated && (<button onClick={handleBulkDownloadLinks} disabled={isDownloadingSelected || downloadableSelectedCount === 0} className="btn-success-xs flex items-center"><Download size={14} className="mr-1.5"/>Download ({downloadableSelectedCount})</button>)}
+            {(role === 'admin' || role === 'super_admin') && (<button onClick={handleOpenBulkMoveLinksModal} disabled={isMovingSelected} className="btn-warning-xs flex items-center"><Move size={14} className="mr-1.5"/>Move</button>)}
+          </div>
         </div>
       )}
 
-      <div className="flex space-x-4 items-center">
-        {softwareList.length > 0 && ( <FilterTabs software={softwareList} selectedSoftwareId={activeSoftwareId} onSelectFilter={handleSoftwareFilterChange} /> )}
-        {activeSoftwareId && versionList.length > 0 && (
-          <div className="relative">
-            <select value={activeVersionId || ''} onChange={handleVersionFilterChange} className="block appearance-none w-full bg-white border border-gray-300 text-gray-700 py-2 px-4 pr-8 rounded-md leading-tight focus:outline-none focus:bg-white focus:border-blue-500 shadow-sm text-sm">
-              <option value="">All Versions for {softwareList.find(s=>s.id === activeSoftwareId)?.name || 'Selected Software'}</option>
-              {versionList.map(version => ( <option key={version.id} value={version.id}>{version.version_number}</option> ))}
-            </select>
-            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700"> <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg> </div>
-          </div>
-        )}
-      </div>
-      
-      <div className="my-4">
-        <button
-          onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
-          className="flex items-center px-4 py-2 bg-gray-200 text-gray-700 hover:bg-gray-300 rounded-md text-sm font-medium"
-        >
-          {showAdvancedFilters ? ( <><ChevronUp size={18} className="mr-2" /> Hide Advanced Filters</> ) : ( <><Filter size={18} className="mr-2" /> Show Advanced Filters</> )}
+      <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-4">
+        <div className="flex flex-col md:flex-row md:items-end gap-4">
+            {softwareList.length > 0 && <FilterTabs software={softwareList} selectedSoftwareId={activeSoftwareId} onSelectFilter={handleSoftwareFilterChange} />}
+            {activeSoftwareId && (
+            <div className="flex flex-col min-w-[200px]">
+                <label htmlFor="versionFilterLinks" className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Version</label>
+                <select id="versionFilterLinks" value={activeVersionId || ''} onChange={handleVersionFilterChange} className="input-class" disabled={versionList.length === 0}>
+                <option value="">All Versions</option>
+                {versionList.map(v => (<option key={v.id} value={v.id}>{v.version_number}</option>))}
+                </select>
+            </div>
+            )}
+        </div>
+        <button onClick={() => setShowAdvancedFilters(p => !p)} className="btn-secondary text-sm flex items-center self-start md:self-end">
+            {showAdvancedFilters ? <ChevronUp size={18} className="mr-1.5" /> : <Filter size={18} className="mr-1.5" />} Advanced Filters
         </button>
       </div>
 
       {showAdvancedFilters && (
-        <div className="my-4 p-4 border rounded-md bg-gray-50 space-y-4 md:space-y-0 md:flex md:flex-wrap md:items-end md:gap-4">
+        <div className="my-4 p-4 border dark:border-gray-600 rounded-md bg-gray-50 dark:bg-gray-700 space-y-4 md:space-y-0 md:flex md:flex-wrap md:items-end md:gap-4">
           <div className="flex flex-col">
-            <label htmlFor="linkTypeFilterSelect" className="text-sm font-medium text-gray-700 mb-1">Link Type</label>
-            <select id="linkTypeFilterSelect" value={linkTypeFilter} onChange={(e) => setLinkTypeFilter(e.target.value)} className="px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
-              <option value="">All</option> <option value="external">External</option> <option value="uploaded">Uploaded File</option>
+            <label htmlFor="linkTypeFilterSelect" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Link Type</label>
+            <select id="linkTypeFilterSelect" value={linkTypeFilter} onChange={(e) => setLinkTypeFilter(e.target.value)} className="input-class">
+              <option value="">All</option> <option value="external">External URL</option> <option value="uploaded">Uploaded File</option>
             </select>
           </div>
           <div className="flex flex-col">
-            <label className="text-sm font-medium text-gray-700 mb-1">Created Between</label>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Created Between</label>
             <div className="flex items-center gap-2">
-              <input type="date" value={createdFromFilter} onChange={(e) => setCreatedFromFilter(e.target.value)} className="px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
-              <span className="text-gray-500">and</span>
-              <input type="date" value={createdToFilter} onChange={(e) => setCreatedToFilter(e.target.value)} className="px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" />
+              <input type="date" value={createdFromFilter} onChange={(e) => setCreatedFromFilter(e.target.value)} className="input-class" />
+              <span className="text-gray-500 dark:text-gray-400">to</span>
+              <input type="date" value={createdToFilter} onChange={(e) => setCreatedToFilter(e.target.value)} className="input-class" />
             </div>
           </div>
-          <div className="flex items-end gap-2 pt-5">
-            <button onClick={handleApplyAdvancedFilters} className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 text-sm">Apply Filters</button>
-            <button onClick={handleClearAdvancedFilters} className="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 text-sm">Clear Filters</button>
-          </div>
+          <div className="flex items-end gap-2 pt-5"><button onClick={handleApplyAdvancedFilters} className="btn-primary text-sm">Apply</button><button onClick={handleClearAllFiltersAndSearch} className="btn-secondary text-sm">Clear All</button></div>
         </div>
       )}
 
-      {isInitialLoad && isLoading ? ( <LoadingState /> ) : error && isInitialLoad && links.length === 0 ? ( <ErrorState message={error} onRetry={loadLinks} /> ) : !isLoading && filteredLinksBySearch.length === 0 ? (
-        <Box sx={{ textAlign: 'center', mt: 4, p: 3 }}>
-          <LinkIcon size={60} className="text-gray-400 dark:text-gray-500 mb-4" />
-          <Typography variant="h6" color="text.secondary">
-            No links found.
-          </Typography>
-        </Box>
+      {isLoadingInitial ? (
+        <div className="py-10"><LoadingState message="Loading links..." /></div>
+      ) : error && links.length === 0 && !isLoadingInitial ? (
+        <ErrorState message={error} onRetry={loadLinksCallback} />
+      ) : !isLoadingInitial && !error && links.length === 0 ? (
+        <div className="text-center py-10 bg-white dark:bg-gray-800 rounded-lg shadow-sm my-6">
+          <LinkIconLucide size={48} className="mx-auto text-yellow-500 dark:text-yellow-400 mb-4" />
+          <p className="text-xl font-semibold text-gray-700 dark:text-gray-200 mb-3">
+            {filtersAreActive ? "No Links Found Matching Criteria" : "No Links Available"}
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 px-4">
+            {filtersAreActive ? "Try adjusting or clearing your search/filter settings." : 
+             (role==='admin'||role==='super_admin') ? "Add new links to get started." : "Please check back later."}
+          </p>
+          {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 btn-primary text-sm">Clear All Filters & Search</button>)}
+        </div>
       ) : (
-        <>
-          <DataTable columns={columns} data={filteredLinksBySearch} rowClassName="group" isLoading={isLoading && !isInitialLoad} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalLinks} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} />
-        </>
+        <DataTable columns={columns} data={filteredLinksBySearch} rowClassName="group" isLoading={isLoadingInitial || isProcessingSingleItem} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalLinks} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedLinkIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
       )}
 
-      {showDeleteConfirm && linkToDelete && ( <ConfirmationModal isOpen={showDeleteConfirm} title="Delete Link" message={`Are you sure you want to delete the link "${linkToDelete.title}"? This action cannot be undone.`} onConfirm={handleDeleteConfirm} onCancel={closeDeleteConfirm} isConfirming={isDeleting} confirmButtonText="Delete" confirmButtonVariant="danger" /> )}
+      {showDeleteConfirm && linkToDelete && (<ConfirmationModal isOpen={showDeleteConfirm} title="Delete Link" message={`Delete "${linkToDelete.title}"?`} onConfirm={handleDeleteLinkConfirm} onCancel={closeDeleteConfirm} isConfirming={isProcessingSingleItem} confirmButtonText="Delete" confirmButtonVariant="danger"/>)}
+      {showBulkDeleteConfirmModal && (<ConfirmationModal isOpen={showBulkDeleteConfirmModal} title={`Delete ${selectedLinkIds.size} Link(s)`} message={`Delete ${selectedLinkIds.size} selected items?`} onConfirm={confirmBulkDeleteLinks} onCancel={()=>setShowBulkDeleteConfirmModal(false)} isConfirming={isDeletingSelected} confirmButtonText="Delete Selected" confirmButtonVariant="danger" Icon={AlertTriangle}/>)}
+      
+      {showBulkMoveModal && (
+        <Modal isOpen={showBulkMoveModal} onClose={()=>setShowBulkMoveModal(false)} title={`Move ${selectedLinkIds.size} Link(s)`}>
+          <div className="p-4">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">Select target Software and optionally a Version:</p>
+            <div className="mb-4">
+              <label htmlFor="modalSoftwareMoveLinks" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Target Software*</label>
+              <select id="modalSoftwareMoveLinks" value={modalSelectedSoftwareId??''} onChange={e=>{setModalSelectedSoftwareId(e.target.value?parseInt(e.target.value):null); setModalSelectedVersionId(undefined);}} className="input-class w-full" disabled={isMovingSelected||softwareList.length===0}>
+                <option value="">Select Software...</option>
+                {softwareList.map(sw=>(<option key={sw.id} value={sw.id}>{sw.name}</option>))}
+              </select>
+            </div>
+            {modalSelectedSoftwareId && (
+              <div className="mb-4">
+                <label htmlFor="modalVersionMoveLinks" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Target Version (Optional)</label>
+                <select id="modalVersionMoveLinks" value={modalSelectedVersionId===null ? 'NULL_VERSION' : modalSelectedVersionId??''} onChange={e=>setModalSelectedVersionId(e.target.value === 'NULL_VERSION' ? null : (e.target.value ? parseInt(e.target.value) : undefined))} className="input-class w-full" disabled={isMovingSelected||isLoadingModalVersions}>
+                  <option value="">{isLoadingModalVersions?'Loading...':'Select Version (Optional)...'}</option>
+                  <option value="NULL_VERSION">No Specific Version (Clear Association)</option>
+                  {modalVersionsList.map(v=>(<option key={v.id} value={v.id}>{v.version_number}</option>))}
+                </select>
+                {modalVersionsList.length===0&&!isLoadingModalVersions&&modalSelectedSoftwareId&&<p className="text-xs text-yellow-600 mt-1">No versions for selected software. You can still move to the software without a specific version.</p>}
+              </div>
+            )}
+            <div className="flex justify-end space-x-3 mt-6">
+              <button type="button" onClick={()=>setShowBulkMoveModal(false)} className="btn-secondary" disabled={isMovingSelected}>Cancel</button>
+              <button type="button" onClick={handleConfirmBulkMoveLinks} className="btn-primary" disabled={isMovingSelected||!modalSelectedSoftwareId}>{isMovingSelected?'Moving...':'Confirm Move'}</button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -1,30 +1,32 @@
 // src/views/MiscView.tsx
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import { useOutletContext } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import {
-  fetchMiscCategories,
-  fetchMiscFiles,
-  deleteAdminMiscCategory,
-  deleteAdminMiscFile,
-  PaginatedMiscFilesResponse,
-  addFavoriteApi,
-  removeFavoriteApi,
-  FavoriteItemType
+  fetchMiscCategories, fetchMiscFiles, deleteAdminMiscCategory, deleteAdminMiscFile,
+  PaginatedMiscFilesResponse, addFavoriteApi, removeFavoriteApi, FavoriteItemType,
+  bulkDeleteItems, bulkDownloadItems, bulkMoveItems, BulkItemType
 } from '../services/api';
 import { MiscCategory, MiscFile } from '../types';
 import DataTable, { ColumnDef } from '../components/DataTable';
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
-import AdminUploadToMiscForm from '../components/admin/AdminUploadToMiscForm';
+import AdminMiscFileForm from '../components/admin/AdminMiscFileForm'; // Using the correct form name
 import AdminMiscCategoryForm from '../components/admin/AdminMiscCategoryForm';
 import ConfirmationModal from '../components/shared/ConfirmationModal';
-import { Download, FileText, CalendarDays, PlusCircle, Edit3, Trash2, Star, Filter, ChevronUp, Archive as ArchiveIcon } from 'lucide-react'; // Added Filter, ChevronUp, ArchiveIcon
-import { Box, Typography } from '@mui/material'; // Added Box and Typography
+import Modal from '../components/shared/Modal';
+import { Download, FileText as FileIconLucide, PlusCircle, Edit3, Trash2, Star, Filter, ChevronUp, Archive as ArchiveIcon, Move, AlertTriangle } from 'lucide-react';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils'; 
 
-const API_BASE_URL = 'http://127.0.0.1:5000';
+const API_BASE_URL = 'http://127.0.0.1:5000'; // Not actively used for constructing URLs here
+
+interface OutletContextType {
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+}
 
 const MiscView: React.FC = () => {
+  const { searchTerm, setSearchTerm } = useOutletContext<OutletContextType>();
   const { isAuthenticated, role } = useAuth();
 
   const [categories, setCategories] = useState<MiscCategory[]>([]);
@@ -32,14 +34,13 @@ const MiscView: React.FC = () => {
   const [errorCategories, setErrorCategories] = useState<string | null>(null);
   
   const [miscFiles, setMiscFiles] = useState<MiscFile[]>([]);
-  const [isLoadingFiles, setIsLoadingFiles] = useState(true);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
   const [errorFiles, setErrorFiles] = useState<string | null>(null);
-  const [isInitialFilesLoad, setIsInitialFilesLoad] = useState(true);
   
   const [activeCategoryId, setActiveCategoryId] = useState<number | null>(null);
 
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [itemsPerPage, setItemsPerPage] = useState<number>(10);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(15);
   const [totalPages, setTotalPages] = useState<number>(0);
   const [totalMiscFiles, setTotalMiscFiles] = useState<number>(0);
 
@@ -48,44 +49,56 @@ const MiscView: React.FC = () => {
 
   const [showCategoryForm, setShowCategoryForm] = useState(false);
   const [editingCategory, setEditingCategory] = useState<MiscCategory | null>(null);
-  const [showGeneralUploadForm, setShowGeneralUploadForm] = useState(false);
+  const [showAddOrEditForm, setShowAddOrEditForm] = useState(false); // For AdminMiscFileForm
+  const [editingMiscFile, setEditingMiscFile] = useState<MiscFile | null>(null);
   const [categoryToDelete, setCategoryToDelete] = useState<MiscCategory | null>(null);
   const [showDeleteCategoryConfirm, setShowDeleteCategoryConfirm] = useState(false);
-  const [isDeletingCategory, setIsDeletingCategory] = useState(false);
+  const [isProcessingCategory, setIsProcessingCategory] = useState(false);
   const [fileToDelete, setFileToDelete] = useState<MiscFile | null>(null);
   const [showDeleteFileConfirm, setShowDeleteFileConfirm] = useState(false);
-  const [isDeletingFile, setIsDeletingFile] = useState(false);
-  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [isProcessingSingleItem, setIsProcessingSingleItem] = useState(false);
 
   const [favoritedItems, setFavoritedItems] = useState<Map<number, { favoriteId: number | undefined }>>(new Map());
-  const [showCategoryFilter, setShowCategoryFilter] = useState(false); // State for category filter toggle, default to false
+  const [showCategoryFilter, setShowCategoryFilter] = useState(true);
+
+  // Bulk Action States
+  const [selectedMiscFileIds, setSelectedMiscFileIds] = useState<Set<number>>(new Set());
+  const [isDeletingSelected, setIsDeletingSelected] = useState<boolean>(false);
+  const [isDownloadingSelected, setIsDownloadingSelected] = useState<boolean>(false);
+  const [isMovingSelected, setIsMovingSelected] = useState<boolean>(false);
+  const [showBulkMoveModal, setShowBulkMoveModal] = useState<boolean>(false);
+  const [modalSelectedCategoryId, setModalSelectedCategoryId] = useState<number | null>(null);
+  const [showBulkDeleteConfirmModal, setShowBulkDeleteConfirmModal] = useState<boolean>(false);
+
+  const filtersAreActive = useMemo(() => {
+    return activeCategoryId !== null || searchTerm !== '';
+  }, [activeCategoryId, searchTerm]);
+
+  const handleClearAllFiltersAndSearch = useCallback(() => {
+    setActiveCategoryId(null);
+    if (setSearchTerm) setSearchTerm('');
+    setCurrentPage(1); 
+  }, [setSearchTerm]);
 
   const loadMiscCategories = useCallback(async () => {
-    setIsLoadingCategories(true);
-    setErrorCategories(null);
+    setIsLoadingCategories(true); setErrorCategories(null);
     try {
-      const data = await fetchMiscCategories();
-      setCategories(data);
+      const data = await fetchMiscCategories(); setCategories(data);
     } catch (err: any) {
-      setCategories([]);
-      const catErrorMessage = err.response?.data?.msg || err.message || 'Failed to load misc categories.';
-      setErrorCategories(catErrorMessage); 
-      showErrorToast(catErrorMessage); 
-      console.error("Error loading misc categories:", err);
-    } finally {
-      setIsLoadingCategories(false);
-    }
+      setCategories([]); const msg = err.response?.data?.msg || err.message || 'Failed to load categories.';
+      setErrorCategories(msg); showErrorToast(msg);
+    } finally { setIsLoadingCategories(false); }
   }, []);
 
-  useEffect(() => { loadMiscCategories(); }, [loadMiscCategories]);
+  useEffect(() => { if (isAuthenticated) loadMiscCategories(); else setCategories([]); }, [isAuthenticated, loadMiscCategories]);
 
-  const loadMiscFiles = useCallback(async () => {
-    setIsLoadingFiles(true);
-    if (isInitialFilesLoad) { setErrorFiles(null); }
+  const fetchAndSetMiscFiles = useCallback(async (pageToLoad: number, isNewQuery: boolean = false) => {
+    if (isNewQuery) setIsLoadingInitial(true);
+    setErrorFiles(null);
 
     try {
       const response: PaginatedMiscFilesResponse = await fetchMiscFiles(
-        activeCategoryId || undefined, currentPage, itemsPerPage, sortBy, sortOrder
+        activeCategoryId || undefined, pageToLoad, itemsPerPage, sortBy, sortOrder
       );
       setMiscFiles(response.misc_files);
       setTotalPages(response.total_pages);
@@ -93,263 +106,247 @@ const MiscView: React.FC = () => {
       setCurrentPage(response.page);
       setItemsPerPage(response.per_page);
 
-      const newFavoritedItems = new Map<number, { favoriteId: number | undefined }>();
-      if (isAuthenticated && response.misc_files && response.misc_files.length > 0) {
-        for (const file of response.misc_files) {
-          if (file.favorite_id) { newFavoritedItems.set(file.id, { favoriteId: file.favorite_id }); } 
-          else { newFavoritedItems.set(file.id, { favoriteId: undefined }); }
-        }
-      }
-      setFavoritedItems(newFavoritedItems);
-
-      if (isInitialFilesLoad) { setIsInitialFilesLoad(false); }
+      const newFavs = new Map<number, { favoriteId: number | undefined }>();
+      if (isAuthenticated && response.misc_files) response.misc_files.forEach(f => newFavs.set(f.id, { favoriteId: f.favorite_id }));
+      setFavoritedItems(newFavs);
     } catch (err: any) {
-      console.error("Failed to load miscellaneous files:", err);
-      const filesErrorMessage = err.response?.data?.msg || err.message || 'Failed to fetch miscellaneous files.';
-      if (isInitialFilesLoad) {
-        setErrorFiles(filesErrorMessage); setMiscFiles([]); setTotalPages(0); setTotalMiscFiles(0); setFavoritedItems(new Map());
-      } else {
-        showErrorToast(filesErrorMessage); 
-      }
+      const msg = err.response?.data?.msg || err.message || 'Failed to fetch files.';
+      if (isNewQuery) { setErrorFiles(msg); setMiscFiles([]); setTotalPages(0); setTotalMiscFiles(0); }
+      else showErrorToast(msg);
     } finally {
-      setIsLoadingFiles(false);
+      if (isNewQuery) setIsLoadingInitial(false);
     }
-  }, [
-    activeCategoryId, currentPage, itemsPerPage, sortBy, sortOrder, 
-    isAuthenticated, isInitialFilesLoad
-  ]);
+  }, [activeCategoryId, itemsPerPage, sortBy, sortOrder, isAuthenticated]);
 
-  useEffect(() => { loadMiscFiles(); }, [loadMiscFiles]);
-  useEffect(() => { if (!isAuthenticated) { setFavoritedItems(new Map()); } }, [isAuthenticated]);
+  useEffect(() => {
+    if (isAuthenticated) fetchAndSetMiscFiles(1, true);
+    else { setMiscFiles([]); setIsLoadingInitial(false); }
+  }, [isAuthenticated, activeCategoryId, sortBy, sortOrder, fetchAndSetMiscFiles]);
+  
+  useEffect(() => { setSelectedMiscFileIds(new Set()); }, [activeCategoryId, sortBy, sortOrder, searchTerm, currentPage]);
 
   const handleCategoryFilterChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const categoryId = event.target.value ? parseInt(event.target.value, 10) : null;
-    setActiveCategoryId(categoryId); setCurrentPage(1); setIsInitialFilesLoad(true); 
+    setActiveCategoryId(event.target.value ? parseInt(event.target.value) : null); setCurrentPage(1);
   };
+  const handlePageChange = (newPage: number) => { setCurrentPage(newPage); fetchAndSetMiscFiles(newPage, true);};
+  const handleSort = (key: string) => { setSortBy(key); setSortOrder(prev => (sortBy === key && prev === 'asc' ? 'desc' : 'asc')); setCurrentPage(1); };
 
-  const handlePageChange = (newPage: number) => { setCurrentPage(newPage); };
-  const handleSort = (columnKey: string) => {
-    if (sortBy === columnKey) { setSortOrder(prevOrder => (prevOrder === 'asc' ? 'desc' : 'asc')); } 
-    else { setSortBy(columnKey); setSortOrder('asc'); }
-    setCurrentPage(1); setIsInitialFilesLoad(true); // Re-fetch on sort with initial load true
+  const handleMiscFileAddedOrUpdated = (file: MiscFile, isEdit: boolean) => {
+    setShowAddOrEditForm(false); setEditingMiscFile(null);
+    showSuccessToast(`File "${file.user_provided_title || file.original_filename}" ${isEdit ? 'updated' : 'uploaded'}.`);
+    fetchAndSetMiscFiles(1, true);
+    // If the file's category matches the active filter or if no filter is active, it will appear.
+    // If it was moved to a new category, and that category is not active, the user might need to change filters.
+    // For simplicity, we don't auto-switch the category filter here.
   };
-
-  const handleMiscFileUploadSuccess = (uploadedFile: MiscFile) => {
-    setShowGeneralUploadForm(false);
-    showSuccessToast(`File "${uploadedFile.user_provided_title || uploadedFile.original_filename}" uploaded successfully.`);
-    if (activeCategoryId === null || activeCategoryId === uploadedFile.misc_category_id) {
-      loadMiscFiles();
-    }
-  };
-
-  const formatDate = (dateString: string | null | undefined): string => {
-    if (!dateString) return 'N/A';
-    try { return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }); } 
-    catch (e) { return "Invalid Date"; }
-  };
+  const handleCategoryOperationSuccess = (message: string) => { setShowCategoryForm(false); setEditingCategory(null); showSuccessToast(message); loadMiscCategories(); };
   
-  const formatFileSize = (bytes: number | null | undefined): string => {
-    if (bytes === null || typeof bytes === 'undefined') return 'N/A';
-    if (bytes === 0) return '0 Bytes';
-    const k = 1024; const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB']; const i = Math.floor(Math.log(bytes) / Math.log(k));
-    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
-  };
-
-  const handleOpenAddCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(true); setFeedbackMessage(null); };
-  const handleOpenEditCategoryForm = (category: MiscCategory) => { setEditingCategory(category); setShowCategoryForm(true); setFeedbackMessage(null);};
-  const handleCloseCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(false); };
-  const handleCategoryOperationSuccess = (message: string) => {
-    setShowCategoryForm(false); setEditingCategory(null); showSuccessToast(message); loadMiscCategories(); 
-  };
-  const handleOpenDeleteCategoryConfirm = (category: MiscCategory) => { setCategoryToDelete(category); setShowDeleteCategoryConfirm(true); setFeedbackMessage(null); };
-  const handleCloseDeleteCategoryConfirm = () => { setCategoryToDelete(null); setShowDeleteCategoryConfirm(false);};
+  const openAddOrEditFileForm = (file?: MiscFile) => { setEditingMiscFile(file || null); setShowAddOrEditForm(true); setShowCategoryForm(false); };
+  const closeAdminFileForm = () => { setEditingMiscFile(null); setShowAddOrEditForm(false); };
+  const openAddCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(true); setShowAddOrEditForm(false); };
+  const openEditCategoryForm = (cat: MiscCategory) => { setEditingCategory(cat); setShowCategoryForm(true); setShowAddOrEditForm(false); };
+  const closeCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(false); };
+  const openDeleteCategoryConfirm = (cat: MiscCategory) => { setCategoryToDelete(cat); setShowDeleteCategoryConfirm(true); };
+  const closeDeleteCategoryConfirm = () => { setCategoryToDelete(null); setShowDeleteCategoryConfirm(false);};
+  const openDeleteFileConfirm = (file: MiscFile) => { setFileToDelete(file); setShowDeleteFileConfirm(true); };
+  const closeDeleteFileConfirm = () => { setFileToDelete(null); setShowDeleteFileConfirm(false);};
   
   const handleDeleteCategoryConfirm = async () => {
     if (!categoryToDelete) return;
-    setIsDeletingCategory(true);
+    setIsProcessingCategory(true);
     try {
       await deleteAdminMiscCategory(categoryToDelete.id);
-      showSuccessToast(`Category "${categoryToDelete.name}" deleted successfully.`);
-      handleCloseDeleteCategoryConfirm(); loadMiscCategories();
-      if (activeCategoryId === categoryToDelete.id) { setActiveCategoryId(null); setIsInitialFilesLoad(true); }
-    } catch (err: any) {
-      const errorMsg = err.response?.data?.msg || err.message || "Failed to delete category.";
-      showErrorToast(errorMsg); 
-      if (!errorMsg.includes("Cannot delete category") && !errorMsg.includes("contains files")) {
-        handleCloseDeleteCategoryConfirm(); 
-      }
-    } finally {
-      setIsDeletingCategory(false);
-    }
+      showSuccessToast(`Category "${categoryToDelete.name}" deleted.`);
+      closeDeleteCategoryConfirm(); loadMiscCategories();
+      if (activeCategoryId === categoryToDelete.id) setActiveCategoryId(null); // Reset filter if active category deleted
+    } catch (err: any) { showErrorToast(err.response?.data?.msg || "Delete failed."); }
+    finally { setIsProcessingCategory(false); }
   };
-
-  const handleOpenDeleteFileConfirm = (file: MiscFile) => { setFileToDelete(file); setShowDeleteFileConfirm(true); setFeedbackMessage(null);};
-  const handleCloseDeleteFileConfirm = () => { setFileToDelete(null); setShowDeleteFileConfirm(false);};
   
   const handleDeleteFileConfirm = async () => {
     if (!fileToDelete) return;
-    setIsDeletingFile(true);
+    setIsProcessingSingleItem(true);
     try {
       await deleteAdminMiscFile(fileToDelete.id);
-      showSuccessToast(`File "${fileToDelete.user_provided_title || fileToDelete.original_filename}" deleted successfully.`);
-      handleCloseDeleteFileConfirm();
-      if (miscFiles.length === 1 && currentPage > 1) { setCurrentPage(currentPage - 1); } 
-      else { loadMiscFiles(); }
-    } catch (err: any) {
-      showErrorToast(err.response?.data?.msg || err.message || "Failed to delete file.");
-      handleCloseDeleteFileConfirm(); 
-    } finally {
-      setIsDeletingFile(false);
-    }
+      showSuccessToast(`File "${fileToDelete.user_provided_title || fileToDelete.original_filename}" deleted.`);
+      closeDeleteFileConfirm(); fetchAndSetMiscFiles(1, true);
+    } catch (err: any) { showErrorToast(err.message || "Delete failed."); closeDeleteFileConfirm(); }
+    finally { setIsProcessingSingleItem(false); }
+  };
+
+  const filteredMiscFilesBySearch = useMemo(() => {
+    if (!searchTerm) return miscFiles;
+    const lower = searchTerm.toLowerCase();
+    return miscFiles.filter(f => (f.user_provided_title||'').toLowerCase().includes(lower) || f.original_filename.toLowerCase().includes(lower) || (f.user_provided_description||'').toLowerCase().includes(lower) || (f.category_name||'').toLowerCase().includes(lower));
+  }, [miscFiles, searchTerm]);
+
+  const handleSelectItem = (id: number, isSelected: boolean) => setSelectedMiscFileIds(prev => { const n = new Set(prev); if (isSelected) n.add(id); else n.delete(id); return n; });
+  const handleSelectAllItems = (isSelected: boolean) => { const n = new Set<number>(); if (isSelected) filteredMiscFilesBySearch.forEach(f => n.add(f.id)); setSelectedMiscFileIds(n); };
+
+  const handleBulkDeleteMiscFilesClick = () => { if (selectedMiscFileIds.size === 0) { showErrorToast("No items selected."); return; } setShowBulkDeleteConfirmModal(true); };
+  const confirmBulkDeleteMiscFiles = async () => {
+    setShowBulkDeleteConfirmModal(false); setIsDeletingSelected(true);
+    try {
+      const res = await bulkDeleteItems(Array.from(selectedMiscFileIds), 'misc_file');
+      showSuccessToast(res.msg || `${res.deleted_count} file(s) deleted.`);
+      setSelectedMiscFileIds(new Set()); fetchAndSetMiscFiles(1, true);
+    } catch (e: any) { showErrorToast(e.message || "Bulk delete failed."); }
+    finally { setIsDeletingSelected(false); }
+  };
+
+  const handleBulkDownloadMiscFiles = async () => {
+    if (selectedMiscFileIds.size === 0) { showErrorToast("No items selected."); return; }
+    setIsDownloadingSelected(true);
+    try {
+      const blob = await bulkDownloadItems(Array.from(selectedMiscFileIds), 'misc_file');
+      const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url;
+      const ts = new Date().toISOString().replace(/:/g, '-'); a.download = `bulk_download_misc_files_${ts}.zip`;
+      document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(url);
+      showSuccessToast('Download started.');
+    } catch (e: any) { showErrorToast(e.message || "Bulk download failed."); }
+    finally { setIsDownloadingSelected(false); }
+  };
+  
+  const handleOpenBulkMoveMiscFilesModal = () => {
+    if (selectedMiscFileIds.size === 0) { showErrorToast("No items selected."); return; }
+    if (categories.length === 0) { showErrorToast("Categories unavailable for move."); return; }
+    setModalSelectedCategoryId(null); setShowBulkMoveModal(true);
+  };
+  const handleConfirmBulkMoveMiscFiles = async () => {
+    if (!modalSelectedCategoryId) { showErrorToast("Select target category."); return; }
+    setShowBulkMoveModal(false); setIsMovingSelected(true);
+    try {
+      const res = await bulkMoveItems(Array.from(selectedMiscFileIds), 'misc_file', { target_misc_category_id: modalSelectedCategoryId });
+      showSuccessToast(res.msg || `${res.moved_count} file(s) moved.`);
+      setSelectedMiscFileIds(new Set()); fetchAndSetMiscFiles(1, true);
+    } catch (e: any) { showErrorToast(e.message || "Bulk move failed."); }
+    finally { setIsMovingSelected(false); setModalSelectedCategoryId(null); }
+  };
+
+  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleDateString('en-CA') : '-';
+  const formatFileSize = (bytes: number|null|undefined) => {
+    if (bytes == null) return 'N/A';
+    if (bytes === 0) return '0 B';
+    const k = 1024; const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
   const columns: ColumnDef<MiscFile>[] = [
-    { key: 'user_provided_title', header: 'Title', sortable: true },
+    { key: 'user_provided_title', header: 'Title', sortable: true, render: f => f.user_provided_title || <span className="italic text-gray-500 dark:text-gray-400">{f.original_filename}</span> },
     { key: 'original_filename', header: 'Original Filename', sortable: true },
     { key: 'category_name', header: 'Category', sortable: true },
-    { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (file) => file.uploaded_by_username || 'N/A' },
-    { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (file) => file.updated_by_username || 'N/A' },
-    { key: 'file_size', header: 'Size', sortable: true, render: (file) => formatFileSize(file.file_size) },
-    { key: 'created_at', header: 'Uploaded At', sortable: true, render: (file) => formatDate(file.created_at) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (file) => formatDate(file.updated_at) },
-    { key: 'file_path', header: 'Link', render: (file) => ( <a href={`${API_BASE_URL}${file.file_path}`} target="_blank" rel="noopener noreferrer" className="flex items-center text-blue-600 hover:text-blue-800" onClick={(e) => e.stopPropagation()}> Download <Download size={14} className="ml-1" /> </a> ) },
-    ...(isAuthenticated ? [{
-      key: 'actions' as keyof MiscFile | 'actions', header: 'Actions',
-      render: (file: MiscFile) => (
-        <div className="flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-          <button onClick={(e) => { e.stopPropagation(); handleFavoriteToggle(file, 'misc_file' as FavoriteItemType);}} className={`p-1 ${favoritedItems.get(file.id)?.favoriteId ? 'text-yellow-500' : 'text-gray-400'} hover:text-yellow-600`} title={favoritedItems.get(file.id)?.favoriteId ? "Remove from Favorites" : "Add to Favorites"}> <Star size={16} className={favoritedItems.get(file.id)?.favoriteId ? "fill-current" : ""} /> </button>
-          {(role === 'admin' || role === 'super_admin') && (
-            <>
-              <button onClick={(e) => { e.stopPropagation(); handleOpenDeleteFileConfirm(file);}} className="p-1 text-red-600 hover:text-red-800" title="Delete File"><Trash2 size={16} /></button>
-            </>
-          )}
-        </div>
-      ),
-    }] : [])
+    { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: f => f.uploaded_by_username||'N/A' },
+    { key: 'file_size', header: 'Size', sortable: true, render: f => formatFileSize(f.file_size) },
+    { key: 'created_at', header: 'Uploaded At', sortable: true, render: f => formatDate(f.created_at) },
+    { key: 'file_path', header: 'Link', render: f => (<a href={`${API_BASE_URL}${f.file_path}`} target="_blank" rel="noopener noreferrer" className="flex items-center text-blue-600 hover:text-blue-800" onClick={e=>e.stopPropagation()}><Download size={14}className="mr-1"/>Download</a>)},
+    { key: 'actions' as any, header: 'Actions', render: (f: MiscFile) => (<div className="flex space-x-1 items-center">{isAuthenticated&&(<button onClick={e=>{e.stopPropagation();handleFavoriteToggle(f,'misc_file')}} className={`p-1 rounded-md ${favoritedItems.get(f.id)?.favoriteId?'text-yellow-500 hover:text-yellow-600':'text-gray-400 hover:text-yellow-500'}`} title={favoritedItems.get(f.id)?.favoriteId?"Remove Favorite":"Add Favorite"}><Star size={16} className={favoritedItems.get(f.id)?.favoriteId?"fill-current":""}/></button>)}{(role==='admin'||role==='super_admin')&&(<> <button onClick={e=>{e.stopPropagation();openAddOrEditFileForm(f)}} className="p-1 text-blue-600 hover:text-blue-800 rounded-md" title="Edit"><Edit3 size={16}/></button> <button onClick={e=>{e.stopPropagation();openDeleteFileConfirm(f)}} className="p-1 text-red-600 hover:text-red-800 rounded-md" title="Delete"><Trash2 size={16}/></button></>)}</div>)},
   ];
+  
+  const loadMiscFilesCallback = useCallback(() => { fetchAndSetMiscFiles(1, true); }, [fetchAndSetMiscFiles]);
 
   const handleFavoriteToggle = async (item: MiscFile, itemType: FavoriteItemType) => {
-    if (!isAuthenticated) { showErrorToast("Please log in to manage favorites."); return; }
+    if (!isAuthenticated) { showErrorToast("Log in to manage favorites."); return; }
     const currentStatus = favoritedItems.get(item.id);
     const isCurrentlyFavorited = !!currentStatus?.favoriteId;
-    const tempFavoritedItems = new Map(favoritedItems);
-    if (isCurrentlyFavorited) { tempFavoritedItems.set(item.id, { favoriteId: undefined }); } 
-    else { tempFavoritedItems.set(item.id, { favoriteId: -1 }); }
-    setFavoritedItems(tempFavoritedItems);
-
+    const tempFavs = new Map(favoritedItems);
+    if (isCurrentlyFavorited) tempFavs.set(item.id, { favoriteId: undefined }); else tempFavs.set(item.id, { favoriteId: -1 });
+    setFavoritedItems(tempFavs);
     try {
+      const name = item.user_provided_title || item.original_filename;
       if (isCurrentlyFavorited && typeof currentStatus?.favoriteId === 'number') {
         await removeFavoriteApi(item.id, itemType);
-        showSuccessToast(`"${item.user_provided_title || item.original_filename}" removed from favorites.`);
-        setFavoritedItems(prev => { const newMap = new Map(prev); newMap.set(item.id, { favoriteId: undefined }); return newMap; });
+        showSuccessToast(`"${name}" removed from favorites.`);
+        setFavoritedItems(prev => { const n = new Map(prev); n.set(item.id, { favoriteId: undefined }); return n; });
       } else {
-        const newFavorite = await addFavoriteApi(item.id, itemType);
-        showSuccessToast(`"${item.user_provided_title || item.original_filename}" added to favorites.`);
-        setFavoritedItems(prev => { const newMap = new Map(prev); newMap.set(item.id, { favoriteId: newFavorite.id }); return newMap; });
+        const newFav = await addFavoriteApi(item.id, itemType);
+        setFavoritedItems(prev => { const n = new Map(prev); n.set(item.id, { favoriteId: newFav.id }); return n; });
+        showSuccessToast(`"${name}" added to favorites.`);
       }
-    } catch (error: any) {
-      showErrorToast(error?.response?.data?.msg || error.message || "Failed to update favorite status.");
-      setFavoritedItems(prev => { 
-        const newMap = new Map(prev);
-        if (isCurrentlyFavorited) { newMap.set(item.id, { favoriteId: currentStatus?.favoriteId });} 
-        else { newMap.set(item.id, { favoriteId: undefined }); }
-        return newMap;
-      });
+    } catch (e: any) {
+      showErrorToast(e?.response?.data?.msg || e.message || "Failed to update favorite.");
+      setFavoritedItems(prev => { const n=new Map(prev); if(isCurrentlyFavorited)n.set(item.id,{favoriteId:currentStatus?.favoriteId}); else n.set(item.id,{favoriteId:undefined}); return n;});
     }
   };
 
   return (
     <div className="space-y-8">
       <div className="flex justify-between items-start sm:items-center mb-6 flex-col sm:flex-row">
-        <div> <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Miscellaneous Files</h2> <p className="text-gray-600 mt-1 dark:text-gray-300">Browse and download categorized miscellaneous files.</p> </div>
-         {isAuthenticated && (role === 'admin' || role === 'super_admin') && (
-            <div className="flex space-x-3 mt-4 sm:mt-0">
-                 <button onClick={() => {setShowCategoryForm(prev => !prev); setEditingCategory(null); setShowGeneralUploadForm(false); setFeedbackMessage(null);}} className="inline-flex items-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
-                    <PlusCircle size={18} className="mr-2" /> {showCategoryForm && !editingCategory ? 'Cancel Add Category' : 'Add/Edit Category'}
-                </button>
-                 <button onClick={() => {setShowGeneralUploadForm(prev => !prev); setShowCategoryForm(false); setEditingCategory(null); setFeedbackMessage(null);}} className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                    <PlusCircle size={18} className="mr-2" /> {showGeneralUploadForm ? 'Cancel Upload' : 'Upload New File'}
-                </button>
-            </div>
+        <div><h2 className="text-2xl font-bold text-gray-800 dark:text-white">Miscellaneous Files</h2><p className="text-gray-600 mt-1 dark:text-gray-300">Manage and browse categorized files.</p></div>
+        {isAuthenticated && (role === 'admin' || role === 'super_admin') && (
+          <div className="flex space-x-3 mt-4 sm:mt-0">
+            <button onClick={showCategoryForm && !editingCategory ? closeCategoryForm : openAddCategoryForm} className="btn-secondary flex items-center"><PlusCircle size={18} className="mr-2"/>{showCategoryForm && !editingCategory ? 'Cancel' : 'Add/Edit Category'}</button>
+            <button onClick={showAddOrEditForm && !editingMiscFile ? closeAdminFileForm : () => openAddOrEditFileForm()} className="btn-primary flex items-center"><PlusCircle size={18} className="mr-2"/>{showAddOrEditForm && !editingMiscFile ? 'Cancel' : 'Upload New File'}</button>
+          </div>
         )}
       </div>
 
-      {feedbackMessage && <div className="p-3 my-2 bg-green-100 text-green-700 rounded text-sm">{feedbackMessage}</div>}
+      {showCategoryForm && (<div className="my-4 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"><AdminMiscCategoryForm categoryToEdit={editingCategory} onSuccess={(cat)=>handleCategoryOperationSuccess(`Category "${cat.name}" saved.`)} onCancel={closeCategoryForm}/></div>)}
+      {showAddOrEditForm && (<div className="my-4 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"><AdminMiscFileForm fileToEdit={editingMiscFile} onFileAdded={(f)=>handleMiscFileAddedOrUpdated(f,false)} onFileUpdated={(f)=>handleMiscFileAddedOrUpdated(f,true)} onCancelEdit={closeAdminFileForm}/></div>)}
 
-      {showCategoryForm && isAuthenticated && (role === 'admin' || role === 'super_admin') && (
-        <div className="my-4 p-4 bg-gray-50 rounded-lg shadow">
-          <AdminMiscCategoryForm
-            categoryToEdit={editingCategory}
-            onSuccess={(category: MiscCategory) => handleCategoryOperationSuccess(`Category "${category.name}" saved successfully.`)}
-            onCancel={handleCloseCategoryForm}
-          />
-        </div>
-      )}
-      {showGeneralUploadForm && isAuthenticated && (role === 'admin' || role === 'super_admin') && ( <div className="my-4 p-4 bg-gray-50 rounded-lg shadow"> <AdminUploadToMiscForm onUploadSuccess={handleMiscFileUploadSuccess} /> </div> )}
-      
-      {isAuthenticated && (role === 'admin' || role === 'super_admin') && (
-        <div className="my-8 p-4 border border-gray-200 rounded-lg shadow">
-          <h3 className="text-lg font-semibold mb-4 text-gray-700">Manage Categories</h3>
-          {isLoadingCategories && <LoadingState type="table" count={3} message="Loading categories..." />}
-          {errorCategories && !isLoadingCategories && categories.length === 0 && <ErrorState message={errorCategories} onRetry={loadMiscCategories} />}
-          {!isLoadingCategories && !errorCategories && categories.length === 0 && ( <p className="text-sm text-gray-500">No categories found. Add one using the "Add/Edit Category" button above.</p> )}
-          {!isLoadingCategories && !errorCategories && categories.length > 0 && (
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50"><tr><th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th><th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th><th scope="col" className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th></tr></thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {categories.map(category => (
-                    <tr key={category.id} className="group hover:bg-gray-50 transition-colors">
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">{category.name}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 truncate max-w-md" title={category.description || ''}>{category.description || <span className="italic text-gray-400">No description</span>}</td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                        <div className="flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-                          <button onClick={() => handleOpenEditCategoryForm(category)} className="text-blue-600 hover:text-blue-800 p-1" title="Edit Category"><Edit3 size={16} /></button>
-                          <button onClick={() => handleOpenDeleteCategoryConfirm(category)} className="text-red-600 hover:text-red-800 p-1" title="Delete Category"><Trash2 size={16} /></button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
+      {selectedMiscFileIds.size > 0 && (
+        <div className="my-4 p-3 bg-gray-100 dark:bg-gray-700 rounded-md shadow-sm border border-gray-200 dark:border-gray-600">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{selectedMiscFileIds.size} item(s) selected</span>
+            {(role==='admin'||role==='super_admin')&&(<button onClick={handleBulkDeleteMiscFilesClick} disabled={isDeletingSelected} className="btn-danger-xs flex items-center"><Trash2 size={14} className="mr-1.5"/>Delete</button>)}
+            {isAuthenticated && (<button onClick={handleBulkDownloadMiscFiles} disabled={isDownloadingSelected} className="btn-success-xs flex items-center"><Download size={14} className="mr-1.5"/>Download</button>)}
+            {(role==='admin'||role==='super_admin')&&(<button onClick={handleOpenBulkMoveMiscFilesModal} disabled={isMovingSelected} className="btn-warning-xs flex items-center"><Move size={14} className="mr-1.5"/>Move</button>)}
+          </div>
         </div>
       )}
 
       <div className="my-4">
-        <button
-          onClick={() => setShowCategoryFilter(!showCategoryFilter)}
-          className="flex items-center px-4 py-2 bg-gray-200 text-gray-700 hover:bg-gray-300 rounded-md text-sm font-medium mb-2"
-        >
-          {showCategoryFilter ? ( <><ChevronUp size={18} className="mr-2" /> Hide Category Filter</> ) : ( <><Filter size={18} className="mr-2" /> Show Category Filter</> )}
+        <button onClick={()=>setShowCategoryFilter(p => !p)} className="flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-md text-sm font-medium mb-2">
+          {showCategoryFilter ? <ChevronUp size={18}className="mr-2"/> : <Filter size={18}className="mr-2"/>} Category Filter
         </button>
         {showCategoryFilter && (
           <>
-            <label htmlFor="category-filter" className="block text-sm font-medium text-gray-700 mb-1">Filter by Category:</label>
-            <select id="category-filter" value={activeCategoryId === null ? '' : activeCategoryId} onChange={handleCategoryFilterChange} className="block w-full sm:w-1/3 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md shadow-sm" disabled={isLoadingCategories || categories.length === 0}>
+            <label htmlFor="category-filter" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1 sr-only">Filter by Category</label>
+            <select id="category-filter" value={activeCategoryId??''} onChange={handleCategoryFilterChange} className="input-class w-full md:w-1/3" disabled={isLoadingCategories||categories.length===0}>
               <option value="">All Categories</option>
-              {categories.map(category => ( <option key={category.id} value={category.id}>{category.name}</option> ))}
+              {categories.map(c=>(<option key={c.id} value={c.id}>{c.name}</option>))}
             </select>
           </>
         )}
       </div>
 
-      {isInitialFilesLoad && isLoadingFiles ? ( <LoadingState /> ) : errorFiles && isInitialFilesLoad && miscFiles.length === 0 ? ( <ErrorState message={errorFiles} onRetry={loadMiscFiles} /> ) : !isLoadingFiles && miscFiles.length === 0 ? (
-        <Box sx={{ textAlign: 'center', mt: 4, p: 3 }}>
-          <ArchiveIcon size={60} className="text-gray-400 dark:text-gray-500 mb-4" />
-          <Typography variant="h6" color="text.secondary">
-            {activeCategoryId ? "No files found in this category." : "No files found."}
-          </Typography>
-        </Box>
-      ) : (
-        <>
-          <DataTable columns={columns} data={miscFiles} rowClassName="group" isLoading={isLoadingFiles && !isInitialFilesLoad} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalMiscFiles} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} />
-        </>
+      {isLoadingInitial ? (<div className="py-10"><LoadingState message="Loading files..." /></div>)
+        : errorFiles && miscFiles.length === 0 && !isLoadingInitial ? (<ErrorState message={errorFiles} onRetry={loadMiscFilesCallback} />)
+        : !isLoadingInitial && !errorFiles && miscFiles.length === 0 ? (
+          <div className="text-center py-10 bg-white dark:bg-gray-800 rounded-lg shadow-sm my-6">
+            <ArchiveIcon size={48} className="mx-auto text-yellow-500 dark:text-yellow-400 mb-4" />
+            <p className="text-xl font-semibold text-gray-700 dark:text-gray-200 mb-3">{filtersAreActive ? "No Files Found Matching Criteria" : "No Files Available"}</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 px-4">{filtersAreActive ? "Try adjusting or clearing your search/filter settings." : 
+             (role==='admin'||role==='super_admin') ? "Upload new files to get started." : "Please check back later."}</p>
+            {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 btn-primary text-sm">Clear All Filters & Search</button>)}
+          </div>
+        ) : (
+          <DataTable columns={columns} data={filteredMiscFilesBySearch} rowClassName="group" isLoading={isLoadingInitial || isProcessingSingleItem} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalMiscFiles} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedMiscFileIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
       )}
 
-      {showDeleteCategoryConfirm && categoryToDelete && ( <ConfirmationModal isOpen={showDeleteCategoryConfirm} title="Delete Category" message={`Are you sure you want to delete the category "${categoryToDelete.name}"? This action cannot be undone.`} onConfirm={handleDeleteCategoryConfirm} onCancel={handleCloseDeleteCategoryConfirm} isConfirming={isDeletingCategory} confirmButtonText={"Delete"} confirmButtonVariant="danger" /> )}
-      {showDeleteFileConfirm && fileToDelete && ( <ConfirmationModal isOpen={showDeleteFileConfirm} title="Delete File" message={`Are you sure you want to delete the file "${fileToDelete.user_provided_title || fileToDelete.original_filename}"?`} onConfirm={handleDeleteFileConfirm} onCancel={handleCloseDeleteFileConfirm} isConfirming={isDeletingFile} confirmButtonText="Delete" confirmButtonVariant="danger" /> )}
+      {showDeleteCategoryConfirm && categoryToDelete && (<ConfirmationModal isOpen={showDeleteCategoryConfirm} title="Delete Category" message={`Delete category "${categoryToDelete.name}"? Files in it won't be deleted but will become uncategorized.`} onConfirm={handleDeleteCategoryConfirm} onCancel={closeDeleteCategoryConfirm} isConfirming={isProcessingCategory} confirmButtonText="Delete" confirmButtonVariant="danger"/>)}
+      {showDeleteFileConfirm && fileToDelete && (<ConfirmationModal isOpen={showDeleteFileConfirm} title="Delete File" message={`Delete "${fileToDelete.user_provided_title||fileToDelete.original_filename}"?`} onConfirm={handleDeleteFileConfirm} onCancel={closeDeleteFileConfirm} isConfirming={isProcessingSingleItem} confirmButtonText="Delete" confirmButtonVariant="danger"/>)}
+      {showBulkDeleteConfirmModal && (<ConfirmationModal isOpen={showBulkDeleteConfirmModal} title={`Delete ${selectedMiscFileIds.size} File(s)`} message={`Delete ${selectedMiscFileIds.size} selected items?`} onConfirm={confirmBulkDeleteMiscFiles} onCancel={()=>setShowBulkDeleteConfirmModal(false)} isConfirming={isDeletingSelected} confirmButtonText="Delete Selected" confirmButtonVariant="danger" Icon={AlertTriangle}/>)}
+      
+      {showBulkMoveModal && (
+        <Modal isOpen={showBulkMoveModal} onClose={()=>setShowBulkMoveModal(false)} title={`Move ${selectedMiscFileIds.size} File(s)`}>
+          <div className="p-4">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">Select target category:</p>
+            <div className="mb-4">
+              <label htmlFor="modalCategoryMove" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Target Category*</label>
+              <select id="modalCategoryMove" value={modalSelectedCategoryId??''} onChange={e=>setModalSelectedCategoryId(e.target.value?parseInt(e.target.value):null)} className="input-class w-full" disabled={isMovingSelected||categories.length===0}>
+                <option value="">Select Category...</option>
+                {categories.map(c=>(<option key={c.id} value={c.id}>{c.name}</option>))}
+              </select>
+              {categories.length===0&&<p className="text-xs text-red-500 mt-1">Categories unavailable.</p>}
+            </div>
+            <div className="flex justify-end space-x-3 mt-6">
+              <button type="button" onClick={()=>setShowBulkMoveModal(false)} className="btn-secondary" disabled={isMovingSelected}>Cancel</button>
+              <button type="button" onClick={handleConfirmBulkMoveMiscFiles} className="btn-primary" disabled={isMovingSelected||!modalSelectedCategoryId}>{isMovingSelected?'Moving...':'Confirm Move'}</button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 };

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -1,8 +1,7 @@
 // src/views/PatchesView.tsx
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { ExternalLink, PlusCircle, Edit3, Trash2, Star, Filter, ChevronUp, Package as PackageIcon } from 'lucide-react'; // Added Filter, ChevronUp, PackageIcon
-import { Box, Typography } from '@mui/material'; // Added Box and Typography
+import { ExternalLink, PlusCircle, Edit3, Trash2, Star, Filter, ChevronUp, Download, Move, AlertTriangle, Package as PackageIcon } from 'lucide-react';
 import { 
   fetchPatches, 
   fetchSoftware, 
@@ -10,7 +9,13 @@ import {
   PaginatedPatchesResponse,
   addFavoriteApi,
   removeFavoriteApi,
-  FavoriteItemType 
+  FavoriteItemType,
+  fetchVersionsForSoftware, // For Move Modal
+  SoftwareVersion,          // For Move Modal
+  bulkDeleteItems,
+  bulkDownloadItems,
+  bulkMoveItems,
+  BulkItemType,
 } from '../services/api';
 import { Patch as PatchType, Software } from '../types';
 import DataTable, { ColumnDef } from '../components/DataTable';
@@ -20,14 +25,16 @@ import ErrorState from '../components/ErrorState';
 import { useAuth } from '../context/AuthContext';
 import AdminPatchEntryForm from '../components/admin/AdminPatchEntryForm';
 import ConfirmationModal from '../components/shared/ConfirmationModal';
+import Modal from '../components/shared/Modal';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils'; 
 
 interface OutletContextType {
   searchTerm: string;
+  setSearchTerm: (term: string) => void;
 }
 
 const PatchesView: React.FC = () => {
-  const { searchTerm } = useOutletContext<OutletContextType>();
+  const { searchTerm, setSearchTerm } = useOutletContext<OutletContextType>();
   const { isAuthenticated, role } = useAuth();
 
   const [patches, setPatches] = useState<PatchType[]>([]);
@@ -39,40 +46,64 @@ const PatchesView: React.FC = () => {
   const [patchedByDeveloperFilter, setPatchedByDeveloperFilter] = useState<string>('');
   
   const [currentPage, setCurrentPage] = useState<number>(1);
-  const [itemsPerPage, setItemsPerPage] = useState<number>(10);
+  const [itemsPerPage, setItemsPerPage] = useState<number>(15); // Default items per page
   const [totalPages, setTotalPages] = useState<number>(0);
   const [totalPatches, setTotalPatches] = useState<number>(0);
 
   const [sortBy, setSortBy] = useState<string>('patch_name');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
 
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingInitial, setIsLoadingInitial] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
-
+  
   const [showAddOrEditForm, setShowAddOrEditForm] = useState(false);
   const [editingPatch, setEditingPatch] = useState<PatchType | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [patchToDelete, setPatchToDelete] = useState<PatchType | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [feedbackMessage, setFeedbackMessage] = useState<string | null>(null);
+  const [isProcessingSingleItem, setIsProcessingSingleItem] = useState(false);
 
   const [favoritedItems, setFavoritedItems] = useState<Map<number, { favoriteId: number | undefined }>>(new Map());
-  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false); // State for filter toggle
+  const [showAdvancedFilters, setShowAdvancedFilters] = useState(false); 
 
-  const loadPatches = useCallback(async () => {
-    setIsLoading(true);
-    if (isInitialLoad) {
-      setError(null);
-    }
+  // Bulk Action States
+  const [selectedPatchIds, setSelectedPatchIds] = useState<Set<number>>(new Set());
+  const [isDeletingSelected, setIsDeletingSelected] = useState<boolean>(false);
+  const [isDownloadingSelected, setIsDownloadingSelected] = useState<boolean>(false);
+  const [isMovingSelected, setIsMovingSelected] = useState<boolean>(false);
+  const [showBulkMoveModal, setShowBulkMoveModal] = useState<boolean>(false);
+  const [modalSelectedSoftwareId, setModalSelectedSoftwareId] = useState<number | null>(null);
+  const [modalVersionsList, setModalVersionsList] = useState<SoftwareVersion[]>([]);
+  const [modalSelectedVersionId, setModalSelectedVersionId] = useState<number | null>(null);
+  const [showBulkDeleteConfirmModal, setShowBulkDeleteConfirmModal] = useState<boolean>(false);
+  const [isLoadingModalVersions, setIsLoadingModalVersions] = useState<boolean>(false);
+
+  const filtersAreActive = useMemo(() => {
+    return (
+      selectedSoftwareId !== null ||
+      releaseFromFilter !== '' ||
+      releaseToFilter !== '' ||
+      patchedByDeveloperFilter !== '' ||
+      searchTerm !== ''
+    );
+  }, [selectedSoftwareId, releaseFromFilter, releaseToFilter, patchedByDeveloperFilter, searchTerm]);
+
+  const handleClearAllFiltersAndSearch = useCallback(() => {
+    setSelectedSoftwareId(null);
+    setReleaseFromFilter('');
+    setReleaseToFilter('');
+    setPatchedByDeveloperFilter('');
+    if (setSearchTerm) setSearchTerm('');
+  }, [setSearchTerm]);
+
+  const fetchAndSetPatches = useCallback(async (pageToLoad: number, isNewQuery: boolean = false) => {
+    if (isNewQuery) setIsLoadingInitial(true);
+    setError(null);
 
     try {
       const response: PaginatedPatchesResponse = await fetchPatches(
-        selectedSoftwareId === null ? undefined : selectedSoftwareId,
-        currentPage, itemsPerPage, sortBy, sortOrder,
+        selectedSoftwareId ?? undefined, pageToLoad, itemsPerPage, sortBy, sortOrder,
         releaseFromFilter || undefined, releaseToFilter || undefined, patchedByDeveloperFilter || undefined
       );
-
       setPatches(response.patches);
       setTotalPages(response.total_pages);
       setTotalPatches(response.total_patches);
@@ -80,215 +111,252 @@ const PatchesView: React.FC = () => {
       setItemsPerPage(response.per_page);
 
       const newFavoritedItems = new Map<number, { favoriteId: number | undefined }>();
-      if (isAuthenticated && response.patches && response.patches.length > 0) {
+      if (isAuthenticated && response.patches) {
         for (const patch of response.patches) {
-          if (patch.favorite_id) { newFavoritedItems.set(patch.id, { favoriteId: patch.favorite_id }); } 
-          else { newFavoritedItems.set(patch.id, { favoriteId: undefined }); }
+          newFavoritedItems.set(patch.id, { favoriteId: patch.favorite_id });
         }
       }
       setFavoritedItems(newFavoritedItems);
-      if (isInitialLoad) {
-        setIsInitialLoad(false);
-      }
     } catch (err: any) {
-      console.error("Failed to load patches:", err);
-      const errorMessage = err.response?.data?.msg || err.message || 'Failed to fetch patches. Please try again later.';
-      if (isInitialLoad) {
-        setError(errorMessage); setPatches([]); setTotalPages(0); setTotalPatches(0); setFavoritedItems(new Map());
-      } else {
-        showErrorToast(errorMessage);
-      }
+      const msg = err.response?.data?.msg || err.message || 'Failed to fetch patches.';
+      if (isNewQuery) { setError(msg); setPatches([]); setTotalPages(0); setTotalPatches(0); }
+      else showErrorToast(msg);
     } finally {
-      setIsLoading(false);
+      if (isNewQuery) setIsLoadingInitial(false);
     }
-  }, [
-    selectedSoftwareId, currentPage, itemsPerPage, sortBy, sortOrder,
-    releaseFromFilter, releaseToFilter, patchedByDeveloperFilter,
-    isAuthenticated, isInitialLoad
-  ]);
+  }, [selectedSoftwareId, itemsPerPage, sortBy, sortOrder, releaseFromFilter, releaseToFilter, patchedByDeveloperFilter, isAuthenticated]);
   
-  useEffect(() => { if (!isAuthenticated) { setFavoritedItems(new Map()); } }, [isAuthenticated]);
+  useEffect(() => {
+    if (isAuthenticated) fetchAndSetPatches(1, true);
+    else { setPatches([]); setIsLoadingInitial(false); }
+  }, [isAuthenticated, selectedSoftwareId, sortBy, sortOrder, releaseFromFilter, releaseToFilter, patchedByDeveloperFilter, fetchAndSetPatches]);
+
+  useEffect(() => { setSelectedPatchIds(new Set()); }, 
+    [selectedSoftwareId, sortBy, sortOrder, releaseFromFilter, releaseToFilter, patchedByDeveloperFilter, searchTerm, currentPage]
+  );
 
   useEffect(() => {
-    const loadSoftwareForFilters = async () => {
-      try {
-        const softwareData = await fetchSoftware();
-        setSoftwareList(softwareData);
-      } catch (err) {
-        console.error("Failed to load software for filters", err);
-        showErrorToast("Could not load software list for filtering.");
-      }
-    };
-    loadSoftwareForFilters();
-  }, []);
+    if (isAuthenticated) {
+      fetchSoftware().then(setSoftwareList).catch(err => showErrorToast("Failed to load software list."));
+    }
+  }, [isAuthenticated]);
 
-  useEffect(() => { loadPatches(); }, [loadPatches]);
-  
-  const handleApplyAdvancedFilters = () => { setCurrentPage(1); setIsInitialLoad(true); };
-  const handleClearAdvancedFilters = () => {
-    setReleaseFromFilter(''); setReleaseToFilter(''); setPatchedByDeveloperFilter('');
-    setCurrentPage(1); setIsInitialLoad(true);
-  };
-  const handleFilterChange = (softwareId: number | null) => { setSelectedSoftwareId(softwareId); setCurrentPage(1); setIsInitialLoad(true);};
-  const handlePageChange = (newPage: number) => { setCurrentPage(newPage); };
-  const handleSort = (columnKey: string) => {
-    if (sortBy === columnKey) { setSortOrder(prevOrder => (prevOrder === 'asc' ? 'desc' : 'asc')); } 
-    else { setSortBy(columnKey); setSortOrder('asc'); }
-    setCurrentPage(1);  setIsInitialLoad(true);
-  };
+  useEffect(() => {
+    if (modalSelectedSoftwareId) {
+      setIsLoadingModalVersions(true);
+      fetchVersionsForSoftware(modalSelectedSoftwareId)
+        .then(setModalVersionsList)
+        .catch(() => showErrorToast("Failed to load versions for move target."))
+        .finally(() => setIsLoadingModalVersions(false));
+    } else {
+      setModalVersionsList([]);
+    }
+  }, [modalSelectedSoftwareId]);
+
+  const handleFilterChange = (id: number | null) => setSelectedSoftwareId(id);
+  const handleSort = (key: string) => { setSortBy(key); setSortOrder(prev => (sortBy === key && prev === 'asc' ? 'desc' : 'asc')); };
+  const handlePageChange = (newPage: number) => fetchAndSetPatches(newPage, true);
 
   const handleOperationSuccess = (message: string) => {
-    setShowAddOrEditForm(false); setEditingPatch(null);
-    setFeedbackMessage(message); 
-    loadPatches();
+    setShowAddOrEditForm(false); setEditingPatch(null); showSuccessToast(message); fetchAndSetPatches(1, true);
   };
   
-  const openAddForm = () => { setEditingPatch(null); setShowAddOrEditForm(true); setFeedbackMessage(null); };
-  const openEditForm = (patch: PatchType) => { setEditingPatch(patch); setShowAddOrEditForm(true); setFeedbackMessage(null); };
+  const openAddForm = () => { setEditingPatch(null); setShowAddOrEditForm(true); };
+  const openEditForm = (patch: PatchType) => { setEditingPatch(patch); setShowAddOrEditForm(true); };
   const closeAdminForm = () => { setEditingPatch(null); setShowAddOrEditForm(false); };
-  const openDeleteConfirm = (patch: PatchType) => { setPatchToDelete(patch); setShowDeleteConfirm(true); setFeedbackMessage(null); };
+  const openDeleteConfirm = (patch: PatchType) => { setPatchToDelete(patch); setShowDeleteConfirm(true); };
   const closeDeleteConfirm = () => { setPatchToDelete(null); setShowDeleteConfirm(false); };
 
   const handleDeleteConfirm = async () => {
     if (!patchToDelete) return;
-    setIsDeleting(true);
+    setIsProcessingSingleItem(true);
     try {
       await deleteAdminPatch(patchToDelete.id);
-      setFeedbackMessage(`Patch "${patchToDelete.patch_name}" deleted successfully.`);
-      closeDeleteConfirm();
-      if (patches.length === 1 && currentPage > 1) { setCurrentPage(currentPage - 1); } 
-      else { loadPatches(); }
-    } catch (err: any) {
-      showErrorToast(err.response?.data?.msg || err.message || "Failed to delete patch.");
-      closeDeleteConfirm(); 
-    } finally {
-      setIsDeleting(false);
-    }
+      showSuccessToast(`Patch "${patchToDelete.patch_name}" deleted.`);
+      closeDeleteConfirm(); fetchAndSetPatches(1, true);
+    } catch (err: any) { showErrorToast(err.message || "Delete failed."); closeDeleteConfirm(); }
+    finally { setIsProcessingSingleItem(false); }
   };
 
   const filteredPatchesBySearch = useMemo(() => {
     if (!searchTerm) return patches;
-    const lowerSearchTerm = searchTerm.toLowerCase();
-    return patches.filter(patch =>
-      patch.patch_name.toLowerCase().includes(lowerSearchTerm) ||
-      (patch.description || '').toLowerCase().includes(lowerSearchTerm) ||
-      (patch.software_name || '').toLowerCase().includes(lowerSearchTerm) ||
-      (patch.version_number || '').toLowerCase().includes(lowerSearchTerm)
+    const lower = searchTerm.toLowerCase();
+    return patches.filter(p => 
+      p.patch_name.toLowerCase().includes(lower) ||
+      (p.description || '').toLowerCase().includes(lower) ||
+      (p.software_name || '').toLowerCase().includes(lower) ||
+      (p.version_number || '').toLowerCase().includes(lower)
     );
   }, [patches, searchTerm]);
 
-  const formatDate = (dateString: string | null | undefined): string => {
-    if (!dateString) return 'N/A';
-    try { return new Date(dateString).toLocaleDateString('en-CA'); } catch (e) { return 'Invalid Date'; }
+  const handleSelectItem = (id: number, isSelected: boolean) => setSelectedPatchIds(prev => { const n = new Set(prev); if (isSelected) n.add(id); else n.delete(id); return n; });
+  const handleSelectAllItems = (isSelected: boolean) => { const n = new Set<number>(); if (isSelected) filteredPatchesBySearch.forEach(p => n.add(p.id)); setSelectedPatchIds(n); };
+
+  const handleBulkDeleteClick = () => { if (selectedPatchIds.size === 0) { showErrorToast("No items selected."); return; } setShowBulkDeleteConfirmModal(true); };
+  const confirmBulkDeletePatches = async () => {
+    setShowBulkDeleteConfirmModal(false); setIsDeletingSelected(true);
+    try {
+      const res = await bulkDeleteItems(Array.from(selectedPatchIds), 'patch');
+      showSuccessToast(res.msg || `${res.deleted_count} patch(es) deleted.`);
+      setSelectedPatchIds(new Set()); fetchAndSetPatches(1, true);
+    } catch (e: any) { showErrorToast(e.message || "Bulk delete failed."); }
+    finally { setIsDeletingSelected(false); }
   };
 
+  const handleBulkDownloadPatches = async () => {
+    if (selectedPatchIds.size === 0) { showErrorToast("No items selected."); return; }
+    setIsDownloadingSelected(true);
+    try {
+      const blob = await bulkDownloadItems(Array.from(selectedPatchIds), 'patch');
+      const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url;
+      const ts = new Date().toISOString().replace(/:/g, '-'); a.download = `bulk_download_patches_${ts}.zip`;
+      document.body.appendChild(a); a.click(); document.body.removeChild(a); URL.revokeObjectURL(url);
+      showSuccessToast('Download started.');
+    } catch (e: any) { showErrorToast(e.message || "Bulk download failed."); }
+    finally { setIsDownloadingSelected(false); }
+  };
+  
+  const handleOpenBulkMovePatchesModal = () => {
+    if (selectedPatchIds.size === 0) { showErrorToast("No items selected."); return; }
+    if (softwareList.length === 0) { showErrorToast("Software list unavailable."); return; }
+    setModalSelectedSoftwareId(null); setModalSelectedVersionId(null); setShowBulkMoveModal(true);
+  };
+  const handleConfirmBulkMovePatches = async () => {
+    if (!modalSelectedVersionId) { showErrorToast("Select target version."); return; }
+    setShowBulkMoveModal(false); setIsMovingSelected(true);
+    try {
+      const res = await bulkMoveItems(Array.from(selectedPatchIds), 'patch', { target_version_id: modalSelectedVersionId });
+      showSuccessToast(res.msg || `${res.moved_count} patch(es) moved.`);
+      setSelectedPatchIds(new Set()); fetchAndSetPatches(1, true);
+    } catch (e: any) { showErrorToast(e.message || "Bulk move failed."); }
+    finally { setIsMovingSelected(false); setModalSelectedSoftwareId(null); setModalSelectedVersionId(null); }
+  };
+
+  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleDateString('en-CA') : '-';
   const columns: ColumnDef<PatchType>[] = [
-    { key: 'patch_name', header: 'Patch Name', sortable: true },
-    { key: 'software_name', header: 'Software', sortable: true },
+    { key: 'patch_name', header: 'Patch Name', sortable: true }, { key: 'software_name', header: 'Software', sortable: true },
     { key: 'version_number', header: 'Version', sortable: true },
-    { key: 'patch_by_developer', header: 'Patch Developer', sortable: true, render: (patch) => patch.patch_by_developer || '-' },
-    { key: 'description', header: 'Description', render: (patch: PatchType) => ( <span className="text-sm text-gray-600 block max-w-xs truncate" title={patch.description || ''}> {patch.description || '-'} </span> ) },
-    { key: 'release_date', header: 'Release Date', sortable: true, render: (patch) => formatDate(patch.release_date) },
-    { key: 'download_link', header: 'Link', render: (patch: PatchType) => ( <a href={patch.download_link} target={patch.is_external_link || !patch.download_link?.startsWith('/') ? "_blank" : "_self"} rel="noopener noreferrer" className="flex items-center text-blue-600 hover:text-blue-800" onClick={(e) => e.stopPropagation()}> Download <ExternalLink size={14} className="ml-1" /> </a> ) },
-    { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (patch) => patch.uploaded_by_username || 'N/A' },
-    { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (patch) => patch.updated_by_username || 'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: (patch) => formatDate(patch.created_at) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (patch) => formatDate(patch.updated_at) },
-    ...(isAuthenticated ? [{
-      key: 'actions' as keyof PatchType | 'actions', header: 'Actions',
-      render: (patch: PatchType) => (
-        <div className="flex space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-          <button onClick={(e) => { e.stopPropagation(); handleFavoriteToggle(patch, 'patch' as FavoriteItemType);}} className={`p-1 ${favoritedItems.get(patch.id)?.favoriteId ? 'text-yellow-500' : 'text-gray-400'} hover:text-yellow-600`} title={favoritedItems.get(patch.id)?.favoriteId ? "Remove from Favorites" : "Add to Favorites"}> <Star size={16} className={favoritedItems.get(patch.id)?.favoriteId ? "fill-current" : ""} /> </button>
-          {(role === 'admin' || role === 'super_admin') && (
-            <>
-              <button onClick={(e) => { e.stopPropagation(); openEditForm(patch);}} className="p-1 text-blue-600 hover:text-blue-800" title="Edit Patch"><Edit3 size={16} /></button>
-              <button onClick={(e) => { e.stopPropagation(); openDeleteConfirm(patch);}} className="p-1 text-red-600 hover:text-red-800" title="Delete Patch"><Trash2 size={16} /></button>
-            </>
-          )}
-        </div>
-      ),
-    }] : [])
+    { key: 'patch_by_developer', header: 'Developer', sortable: true, render: p => p.patch_by_developer || '-' },
+    { key: 'description', header: 'Description', render: p => <span className="text-sm text-gray-600 block max-w-xs truncate" title={p.description||''}>{p.description||'-'}</span> },
+    { key: 'release_date', header: 'Release Date', sortable: true, render: p => formatDate(p.release_date) },
+    { key: 'download_link', header: 'Link', render: p => <a href={p.download_link} target={p.is_external_link||!p.download_link?.startsWith('/')?"_blank":"_self"} rel="noopener noreferrer" className="flex items-center text-blue-600 hover:text-blue-800" onClick={e=>e.stopPropagation()}><Download size={14}className="mr-1"/>Link</a> },
+    { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: p => p.uploaded_by_username||'N/A' },
+    { key: 'updated_by_username', header: 'Updated By', sortable: false, render: p => p.updated_by_username||'N/A' },
+    { key: 'created_at', header: 'Created At', sortable: true, render: p => formatDate(p.created_at) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, render: p => formatDate(p.updated_at) },
+    { key: 'actions' as any, header: 'Actions', render: (p: PatchType) => (<div className="flex space-x-1 items-center">{isAuthenticated&&(<button onClick={e=>{e.stopPropagation();handleFavoriteToggle(p,'patch')}} className={`p-1 rounded-md ${favoritedItems.get(p.id)?.favoriteId?'text-yellow-500 hover:text-yellow-600':'text-gray-400 hover:text-yellow-500'}`} title={favoritedItems.get(p.id)?.favoriteId?"Remove Favorite":"Add Favorite"}><Star size={16} className={favoritedItems.get(p.id)?.favoriteId?"fill-current":""}/></button>)}{(role==='admin'||role==='super_admin')&&(<> <button onClick={e=>{e.stopPropagation();openEditForm(p)}} className="p-1 text-blue-600 hover:text-blue-800 rounded-md" title="Edit"><Edit3 size={16}/></button> <button onClick={e=>{e.stopPropagation();openDeleteConfirm(p)}} className="p-1 text-red-600 hover:text-red-800 rounded-md" title="Delete"><Trash2 size={16}/></button></>)}</div>)},
   ];
+  
+  const loadPatchesCallback = useCallback(() => { fetchAndSetPatches(1, true); }, [fetchAndSetPatches]);
 
   const handleFavoriteToggle = async (item: PatchType, itemType: FavoriteItemType) => {
     if (!isAuthenticated) { showErrorToast("Please log in to manage favorites."); return; }
     const currentStatus = favoritedItems.get(item.id);
     const isCurrentlyFavorited = !!currentStatus?.favoriteId;
-    const tempFavoritedItems = new Map(favoritedItems);
-    if (isCurrentlyFavorited) { tempFavoritedItems.set(item.id, { favoriteId: undefined }); } 
-    else { tempFavoritedItems.set(item.id, { favoriteId: -1 }); }
-    setFavoritedItems(tempFavoritedItems);
-    setFeedbackMessage(null);
-
+    const tempFavs = new Map(favoritedItems);
+    if (isCurrentlyFavorited) tempFavs.set(item.id, { favoriteId: undefined }); else tempFavs.set(item.id, { favoriteId: -1 });
+    setFavoritedItems(tempFavs);
     try {
       if (isCurrentlyFavorited && typeof currentStatus?.favoriteId === 'number') {
         await removeFavoriteApi(item.id, itemType);
         showSuccessToast(`"${item.patch_name}" removed from favorites.`);
-        setFavoritedItems(prev => { const newMap = new Map(prev); newMap.set(item.id, { favoriteId: undefined }); return newMap; });
+        setFavoritedItems(prev => { const n = new Map(prev); n.set(item.id, { favoriteId: undefined }); return n; });
       } else {
-        const newFavorite = await addFavoriteApi(item.id, itemType);
+        const newFav = await addFavoriteApi(item.id, itemType);
+        setFavoritedItems(prev => { const n = new Map(prev); n.set(item.id, { favoriteId: newFav.id }); return n; });
         showSuccessToast(`"${item.patch_name}" added to favorites.`);
-        setFavoritedItems(prev => { const newMap = new Map(prev); newMap.set(item.id, { favoriteId: newFavorite.id }); return newMap; });
       }
-    } catch (error: any) {
-      showErrorToast(error?.response?.data?.msg || error.message || "Failed to update favorite status.");
-      setFavoritedItems(prev => { 
-        const newMap = new Map(prev);
-        if (isCurrentlyFavorited) { newMap.set(item.id, { favoriteId: currentStatus?.favoriteId });} 
-        else { newMap.set(item.id, { favoriteId: undefined }); }
-        return newMap;
-      });
+    } catch (e: any) {
+      showErrorToast(e?.response?.data?.msg || e.message || "Failed to update favorite.");
+      setFavoritedItems(prev => { const n=new Map(prev); if(isCurrentlyFavorited)n.set(item.id,{favoriteId:currentStatus?.favoriteId}); else n.set(item.id,{favoriteId:undefined}); return n;});
     }
   };
-  
+
   return (
     <div className="space-y-6">
       <div className="flex justify-between items-start sm:items-center mb-6 flex-col sm:flex-row">
-        <div> <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Patches</h2> <p className="text-gray-600 mt-1 dark:text-gray-300">Browse and download software patches</p> </div>
-        {isAuthenticated && (role === 'admin' || role === 'super_admin') && (
-          <button onClick={showAddOrEditForm && !editingPatch ? closeAdminForm : openAddForm} className="mt-4 sm:mt-0 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-            <PlusCircle size={18} className="mr-2" /> {showAddOrEditForm && !editingPatch ? 'Cancel Add Patch' : 'Add New Patch'}
+        <div> <h2 className="text-2xl font-bold text-gray-800 dark:text-white">Patches</h2> <p className="text-gray-600 mt-1 dark:text-gray-300">Browse and manage software patches.</p> </div>
+        {isAuthenticated && (role === 'admin' || role === 'super_admin') && !editingPatch && (
+          <button onClick={showAddOrEditForm ? closeAdminForm : openAddForm} className="mt-4 sm:mt-0 btn-primary">
+            <PlusCircle size={18} className="mr-2" /> {showAddOrEditForm ? 'Cancel' : 'Add New Patch'}
           </button>
         )}
       </div>
 
-      {feedbackMessage && <div className="p-3 my-2 bg-green-100 text-green-700 rounded text-sm">{feedbackMessage}</div>}
+      {showAddOrEditForm && ( <div className="my-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg shadow"> <AdminPatchEntryForm patchToEdit={editingPatch} onPatchAdded={() => handleOperationSuccess('Patch added.')} onPatchUpdated={() => handleOperationSuccess('Patch updated.')} onCancelEdit={closeAdminForm} /> </div> )}
 
-      {showAddOrEditForm && ( <div className="my-6 p-4 bg-gray-50 rounded-lg shadow"> <AdminPatchEntryForm patchToEdit={editingPatch} onPatchAdded={() => handleOperationSuccess('Patch added successfully.')} onPatchUpdated={() => handleOperationSuccess('Patch updated successfully.')} onCancelEdit={closeAdminForm} /> </div> )}
-
-      {softwareList.length > 0 && ( <FilterTabs software={softwareList} selectedSoftwareId={selectedSoftwareId} onSelectFilter={handleFilterChange} /> )}
-      
-      <div className="my-4">
-        <button
-          onClick={() => setShowAdvancedFilters(!showAdvancedFilters)}
-          className="flex items-center px-4 py-2 bg-gray-200 text-gray-700 hover:bg-gray-300 rounded-md text-sm font-medium"
-        >
-          {showAdvancedFilters ? ( <><ChevronUp size={18} className="mr-2" /> Hide Advanced Filters</> ) : ( <><Filter size={18} className="mr-2" /> Show Advanced Filters</> )}
-        </button>
-      </div>
-
-      {showAdvancedFilters && (
-        <div className="my-4 p-4 border rounded-md bg-gray-50 space-y-4 md:space-y-0 md:flex md:flex-wrap md:items-end md:gap-4">
-          <div className="flex flex-col"> <label htmlFor="patchedByDeveloperFilterInput" className="text-sm font-medium text-gray-700 mb-1">Developer</label> <input id="patchedByDeveloperFilterInput" type="text" value={patchedByDeveloperFilter} onChange={(e) => setPatchedByDeveloperFilter(e.target.value)} placeholder="e.g., John Doe" className="px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" /> </div>
-          <div className="flex flex-col"> <label className="text-sm font-medium text-gray-700 mb-1">Released Between</label> <div className="flex items-center gap-2"> <input type="date" value={releaseFromFilter} onChange={(e) => setReleaseFromFilter(e.target.value)} className="px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" /> <span className="text-gray-500">and</span> <input type="date" value={releaseToFilter} onChange={(e) => setReleaseToFilter(e.target.value)} className="px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm" /> </div> </div>
-          <div className="flex items-end gap-2 pt-5"> <button onClick={handleApplyAdvancedFilters} className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 text-sm">Apply Filters</button> <button onClick={handleClearAdvancedFilters} className="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 text-sm">Clear Filters</button> </div>
+      {selectedPatchIds.size > 0 && (
+        <div className="my-4 p-3 bg-gray-100 dark:bg-gray-700 rounded-md shadow-sm border border-gray-200 dark:border-gray-600">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-200">{selectedPatchIds.size} item(s) selected</span>
+            {(role === 'admin' || role === 'super_admin') && (<button onClick={handleBulkDeleteClick} disabled={isDeletingSelected} className="btn-danger-xs flex items-center"><Trash2 size={14} className="mr-1.5"/>Delete</button>)}
+            {isAuthenticated && (<button onClick={handleBulkDownloadPatches} disabled={isDownloadingSelected} className="btn-success-xs flex items-center"><Download size={14} className="mr-1.5"/>Download</button>)}
+            {(role === 'admin' || role === 'super_admin') && (<button onClick={handleOpenBulkMovePatchesModal} disabled={isMovingSelected} className="btn-warning-xs flex items-center"><Move size={14} className="mr-1.5"/>Move</button>)}
+          </div>
         </div>
       )}
 
-      {isInitialLoad && isLoading ? ( <LoadingState /> ) : error && isInitialLoad && patches.length === 0 ? ( <ErrorState message={error} onRetry={loadPatches} /> ) : !isLoading && filteredPatchesBySearch.length === 0 ? (
-        <Box sx={{ textAlign: 'center', mt: 4, p: 3 }}>
-          <PackageIcon size={60} className="text-gray-400 dark:text-gray-500 mb-4" />
-          <Typography variant="h6" color="text.secondary">
-            No patches found.
-          </Typography>
-        </Box>
-      ) : (
-         <>
-        <DataTable columns={columns} data={filteredPatchesBySearch} rowClassName="group" isLoading={isLoading && !isInitialLoad} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalPatches} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} />
-        </>
+      {softwareList.length > 0 && <FilterTabs software={softwareList} selectedSoftwareId={selectedSoftwareId} onSelectFilter={handleFilterChange} />}
+      
+      <div className="my-4"><button onClick={() => setShowAdvancedFilters(p => !p)} className="flex items-center px-4 py-2 bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-md text-sm font-medium">{showAdvancedFilters?(<><ChevronUp size={18}className="mr-2"/>Hide</>):(<><Filter size={18}className="mr-2"/>Show</>)} Advanced Filters</button></div>
+      {showAdvancedFilters && (
+        <div className="my-4 p-4 border dark:border-gray-600 rounded-md bg-gray-50 dark:bg-gray-700 space-y-4 md:space-y-0 md:flex md:flex-wrap md:items-end md:gap-4">
+          <div><label htmlFor="patchedByDevFilter" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Developer</label><input id="patchedByDevFilter" type="text" value={patchedByDeveloperFilter} onChange={e=>setPatchedByDeveloperFilter(e.target.value)} placeholder="e.g., Main Dev" className="input-class"/></div>
+          <div><label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Released</label><div className="flex items-center gap-2"><input type="date" value={releaseFromFilter} onChange={e=>setReleaseFromFilter(e.target.value)} className="input-class"/><span className="text-gray-500 dark:text-gray-400">to</span><input type="date" value={releaseToFilter} onChange={e=>setReleaseToFilter(e.target.value)} className="input-class"/></div></div>
+          <div className="flex items-end gap-2 pt-5"><button onClick={handleApplyAdvancedFilters} className="btn-primary text-sm">Apply</button><button onClick={handleClearAdvancedFilters} className="btn-secondary text-sm">Clear</button></div>
+        </div>
       )}
 
-      {showDeleteConfirm && patchToDelete && ( <ConfirmationModal isOpen={showDeleteConfirm} title="Delete Patch" message={`Are you sure you want to delete the patch "${patchToDelete.patch_name}"? This action cannot be undone.`} onConfirm={handleDeleteConfirm} onCancel={closeDeleteConfirm} isConfirming={isDeleting} confirmButtonText="Delete" confirmButtonVariant="danger" /> )}
+      {isLoadingInitial ? (
+        <div className="py-10"><LoadingState message="Loading patches..." /></div>
+      ) : error && patches.length === 0 && !isLoadingInitial ? (
+        <ErrorState message={error} onRetry={loadPatchesCallback} />
+      ) : !isLoadingInitial && !error && patches.length === 0 ? (
+        <div className="text-center py-10 bg-white dark:bg-gray-800 rounded-lg shadow-sm my-6">
+          <PackageIcon size={48} className="mx-auto text-yellow-500 dark:text-yellow-400 mb-4" />
+          <p className="text-xl font-semibold text-gray-700 dark:text-gray-200 mb-3">
+            {filtersAreActive ? "No Patches Found Matching Criteria" : "No Patches Available"}
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 px-4">
+            {filtersAreActive ? "Try adjusting or clearing your search/filter settings." : 
+             (role==='admin'||role==='super_admin') ? "Add new patches to get started." : "Please check back later."}
+          </p>
+          {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 btn-primary text-sm">Clear All Filters & Search</button>)}
+        </div>
+      ) : (
+        <DataTable columns={columns} data={filteredPatchesBySearch} rowClassName="group" isLoading={isLoadingInitial || isProcessingSingleItem} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalPatches} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedPatchIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
+      )}
+
+      {showDeleteConfirm && patchToDelete && (<ConfirmationModal isOpen={showDeleteConfirm} title="Delete Patch" message={`Delete "${patchToDelete.patch_name}"?`} onConfirm={handleDeleteConfirm} onCancel={closeDeleteConfirm} isConfirming={isProcessingSingleItem} confirmButtonText="Delete" confirmButtonVariant="danger"/>)}
+      {showBulkDeleteConfirmModal && (<ConfirmationModal isOpen={showBulkDeleteConfirmModal} title={`Delete ${selectedPatchIds.size} Patch(es)`} message={`Delete ${selectedPatchIds.size} selected items?`} onConfirm={confirmBulkDeletePatches} onCancel={()=>setShowBulkDeleteConfirmModal(false)} isConfirming={isDeletingSelected} confirmButtonText="Delete Selected" confirmButtonVariant="danger" Icon={AlertTriangle}/>)}
+      {showBulkMoveModal && (
+        <Modal isOpen={showBulkMoveModal} onClose={()=>setShowBulkMoveModal(false)} title={`Move ${selectedPatchIds.size} Patch(es)`}>
+          <div className="p-4">
+            <p className="text-sm text-gray-600 dark:text-gray-300 mb-2">Select target Software and Version:</p>
+            <div className="mb-4">
+              <label htmlFor="modalSoftwareMove" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Target Software</label>
+              <select id="modalSoftwareMove" value={modalSelectedSoftwareId??''} onChange={e=>{setModalSelectedSoftwareId(e.target.value?parseInt(e.target.value):null); setModalSelectedVersionId(null);}} className="input-class w-full" disabled={isMovingSelected||softwareList.length===0}>
+                <option value="">Select Software...</option>
+                {softwareList.map(sw=>(<option key={sw.id} value={sw.id}>{sw.name}</option>))}
+              </select>
+            </div>
+            {modalSelectedSoftwareId && (
+              <div className="mb-4">
+                <label htmlFor="modalVersionMove" className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1">Target Version</label>
+                <select id="modalVersionMove" value={modalSelectedVersionId??''} onChange={e=>setModalSelectedVersionId(e.target.value?parseInt(e.target.value):null)} className="input-class w-full" disabled={isMovingSelected||isLoadingModalVersions||modalVersionsList.length===0}>
+                  <option value="">{isLoadingModalVersions?'Loading...':'Select Version...'}</option>
+                  {modalVersionsList.map(v=>(<option key={v.id} value={v.id}>{v.version_number}</option>))}
+                </select>
+                {modalVersionsList.length===0&&!isLoadingModalVersions&&<p className="text-xs text-red-500 mt-1">No versions for selected software.</p>}
+              </div>
+            )}
+            <div className="flex justify-end space-x-3 mt-6">
+              <button type="button" onClick={()=>setShowBulkMoveModal(false)} className="btn-secondary" disabled={isMovingSelected}>Cancel</button>
+              <button type="button" onClick={handleConfirmBulkMovePatches} className="btn-primary" disabled={isMovingSelected||!modalSelectedSoftwareId||!modalSelectedVersionId}>{isMovingSelected?'Moving...':'Confirm Move'}</button>
+            </div>
+          </div>
+        </Modal>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This commit introduces bulk action capabilities (delete, download, move) for documents, patches, links, and miscellaneous files.

Key changes:

Backend:
- Added new API endpoints:
    - `POST /api/bulk/delete`: Admin-only bulk deletion.
    - `POST /api/bulk/download`: Authenticated user bulk download (generates a zip file).
    - `POST /api/bulk/move`: Admin-only bulk move to new software, version, or category.
- Implemented authorization, file system operations for delete/download, database updates, and comprehensive audit logging for all bulk operations.

Frontend:
- Updated `DataTable.tsx` to support row selection via checkboxes and a "select all" feature. Selected rows are visually highlighted.
- Modified `DocumentsView.tsx`, `PatchesView.tsx`, `LinksView.tsx`, and `MiscView.tsx`:
    - Integrated DataTable selection.
    - Added UI elements (action bar, buttons, modals) for bulk operations.
    - Implemented logic to call new bulk action APIs and handle responses.
    - Ensured single-item CRUD operations (add, edit file/URL, delete) in Patches, Links, and Misc views are consistent with DocumentsView.
    - Added context-aware empty state messages when no items are displayed.
- Fixed dark mode text visibility issues on `GlobalLoginPage.tsx` by using MUI theme-aware palette colors.

All bulk actions include appropriate user feedback (toasts, loading states) and permission checks.