### PR TITLE
I've addressed the duplicate toast notifications and investigated the…

### DIFF
--- a/frontend/src/utils/toastUtils.ts
+++ b/frontend/src/utils/toastUtils.ts
@@ -12,7 +12,7 @@ const defaultOptions: ToastOptions = {
   theme: "colored",
 };
 
-const GLOBAL_TOAST_DEBOUNCE_DURATION_MS = 500;
+const GLOBAL_TOAST_DEBOUNCE_DURATION_MS = 1500;
 let lastAnyToastTimestamp: number = 0;
 
 let lastErrorMessage: string | null = null;

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -187,7 +187,7 @@ const LinksView: React.FC = () => {
   const handleOperationSuccess = async (message: string) => { // Made async
     setShowAddOrEditForm(false); 
     setEditingLink(null); 
-    showSuccessToast(message); 
+    /* showSuccessToast(message); */
     await fetchAndSetLinks(1, true); // Await this
 
     // After successful link addition/update, refresh versionList if a software filter is active

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -166,7 +166,7 @@ const role = user?.role; // Access role safely, as user can be null
 
   const handleMiscFileAddedOrUpdated = (file: MiscFile, isEdit: boolean) => {
     setShowAddOrEditForm(false); setEditingMiscFile(null);
-    showSuccessToast(`File "${file.user_provided_title || file.original_filename}" ${isEdit ? 'updated' : 'uploaded'}.`);
+    /* showSuccessToast(`File "${file.user_provided_title || file.original_filename}" ${isEdit ? 'updated' : 'uploaded'}.`); */
     fetchAndSetMiscFiles(1, true);
     // If the file's category matches the active filter or if no filter is active, it will appear.
     // If it was moved to a new category, and that category is not active, the user might need to change filters.

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -222,7 +222,7 @@ useEffect(() => {
   const handlePageChange = (newPage: number) => fetchAndSetPatches(newPage, true);
 
   const handleOperationSuccess = (message: string) => {
-    setShowAddOrEditForm(false); setEditingPatch(null); showSuccessToast(message); fetchAndSetPatches(1, true);
+    setShowAddOrEditForm(false); setEditingPatch(null); /* showSuccessToast(message); */ fetchAndSetPatches(1, true);
   };
   
   const openAddForm = () => { setEditingPatch(null); setShowAddOrEditForm(true); };


### PR DESCRIPTION
… patch moving issue.

Frontend:
- I modified PatchesView, LinksView, and MiscView to remove generic success toasts from their main add/update success handlers. This is to prevent a second, generic toast from appearing after a more specific success toast presumed to be shown by the entry/edit form components. This change aims to ensure only one success notification is displayed per operation.
- I initially increased GLOBAL_TOAST_DEBOUNCE_DURATION_MS in toastUtils.ts to 1500ms, though the primary fix above is more targeted.

Backend/Analysis:
- I investigated the 400 error reported when moving linked patches.
- I concluded that the backend's `bulk_move_items` function correctly handles the update of `version_id` for both linked and file-based patches.
- The 400 error is likely due to the backend's valid conflict resolution mechanism: if all selected patches for a move have `patch_name` conflicts in the target version, a 400 response with details of the conflicts is returned. No changes were made to this backend logic as it appears to be functioning correctly in preventing data integrity issues. The frontend should display the conflict message provided by the backend.