### PR TITLE
Fix: Improve toasts, patch move errors, and backend messages

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -341,6 +341,7 @@ const handleApiError = async (response: Response, defaultMessage: string, isLogi
       // If parsing errorData fails, use a generic message
       errorData = { msg: `${defaultMessage}: ${response.status} ${response.statusText}` };
     }
+    // Removed conditional logging block for /api/bulk/move 400 errors
 
     // Check for 503 Maintenance Mode and if a token was used (i.e., not a login attempt)
     if (response.status === 503 && errorData?.maintenance_mode_active === true && !isLoginAttempt && localStorage.getItem('tokenData')) {
@@ -563,6 +564,7 @@ export async function bulkMoveItems(
   itemType: BulkItemType, 
   targetMetadata: Record<string, any>
 ): Promise<BulkMoveResponse> {
+  // console.log('[api.ts] bulkMoveItems: Sending payload:', { item_ids: itemIds, item_type: itemType, target_metadata: targetMetadata }); // Removed
   try {
     const response = await fetch(`${API_BASE_URL}/api/bulk/move`, {
       method: 'POST',


### PR DESCRIPTION
This commit addresses several issues:
1.  **Duplicate Toast Notifications (Frontend):**
    - Modified PatchesView, LinksView, and MiscView to remove generic success toasts from their main add/update success handlers. This prevents a second, generic toast after a specific form-level toast, ensuring only one notification.
    - (Previously increased global toast debounce in toastUtils.ts).

2.  **Patch Move Conflict Error Display (Frontend - PatchesView):**
    - Enhanced PatchesView.tsx to parse `conflicted_items` from the backend's 400/207 error response during bulk patch moves.
    - A detailed, user-friendly error toast is now shown, listing conflicting patches and guiding you.

3.  **Bulk Move Error Handling (Other Views):**
    - Confirmed backend does not currently check for naming conflicts when moving documents, links, or misc_files. No changes made to error handling in DocumentsView, LinksView, MiscView for this specific conflict type.

4.  **Backend Message Refinement (app.py):**
    - Improved the `msg` field in the `bulk_move_items` response in `app.py` to be more descriptive, especially when naming conflicts occur for patches.

5.  **Logging Bug Fix (app.py):**
    - Corrected an `AttributeError ('sqlite3.Row' object has no attribute 'get')` in a debug logging statement within `bulk_move_items`, resolving a 500 error.

6.  **Debugging Log Removal (Frontend):**
    - Removed temporary console logs from PatchesView.tsx and api.ts used for diagnosing patch move issues.