### PR TITLE
Feat: Implement auto-scroll to top for edit forms

### DIFF
--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -311,7 +311,7 @@ useEffect(() => {
     fetchAndSetDocuments(1, true);
   };
 
-  const openEditForm = (doc: DocumentType) => { setShowAddDocumentForm(false); setEditingDocument(doc); };
+  const openEditForm = (doc: DocumentType) => { setShowAddDocumentForm(false); setEditingDocument(doc); window.scrollTo({ top: 0, behavior: 'smooth' }); };
   const closeEditForm = () => setEditingDocument(null);
   const openDeleteConfirm = (doc: DocumentType) => { setDocumentToDelete(doc); setShowDeleteConfirm(true); };
   const closeDeleteConfirm = () => { setDocumentToDelete(null); setShowDeleteConfirm(false); };

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -206,7 +206,7 @@ const LinksView: React.FC = () => {
     setEditingLink(null);
     setShowAddOrEditForm(true);
   };
-  const openEditForm = (link: LinkType) => { setEditingLink(link); setShowAddOrEditForm(true); };
+  const openEditForm = (link: LinkType) => { setEditingLink(link); setShowAddOrEditForm(true); window.scrollTo({ top: 0, behavior: 'smooth' }); };
   const closeAdminForm = () => {
     setEditingLink(null);
     setShowAddOrEditForm(false);

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -174,7 +174,7 @@ const role = user?.role; // Access role safely, as user can be null
   };
   const handleCategoryOperationSuccess = (message: string) => { setShowCategoryForm(false); setEditingCategory(null); showSuccessToast(message); loadMiscCategories(); };
   
-  const openAddOrEditFileForm = (file?: MiscFile) => { setEditingMiscFile(file || null); setShowAddOrEditForm(true); setShowCategoryForm(false); };
+  const openAddOrEditFileForm = (file?: MiscFile) => { setEditingMiscFile(file || null); setShowAddOrEditForm(true); setShowCategoryForm(false); if (file) { window.scrollTo({ top: 0, behavior: 'smooth' }); } };
   const closeAdminFileForm = () => { setEditingMiscFile(null); setShowAddOrEditForm(false); };
   const openAddCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(true); setShowAddOrEditForm(false); };
   const closeCategoryForm = () => { setEditingCategory(null); setShowCategoryForm(false); };

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -226,7 +226,7 @@ useEffect(() => {
   };
   
   const openAddForm = () => { setEditingPatch(null); setShowAddOrEditForm(true); };
-  const openEditForm = (patch: PatchType) => { setEditingPatch(patch); setShowAddOrEditForm(true); };
+  const openEditForm = (patch: PatchType) => { setEditingPatch(patch); setShowAddOrEditForm(true); window.scrollTo({ top: 0, behavior: 'smooth' }); };
   const closeAdminForm = () => { setEditingPatch(null); setShowAddOrEditForm(false); };
   const openDeleteConfirm = (patch: PatchType) => { setPatchToDelete(patch); setShowDeleteConfirm(true); };
   const closeDeleteConfirm = () => { setPatchToDelete(null); setShowDeleteConfirm(false); };


### PR DESCRIPTION
Adds an auto-scroll-to-top functionality when an edit form is opened on the following pages:
- PatchesView
- DocumentsView
- LinksView
- MiscView (for editing misc files)

When you click an edit icon for an item in these views, and the corresponding edit form appears (typically at the top of the view), the page will now automatically scroll smoothly to the top. This ensures you can immediately see and interact with the edit form without needing to manually scroll up, improving user experience, especially on long pages.

The change involves adding `window.scrollTo({ top: 0, behavior: 'smooth' });` to the respective functions that handle opening the edit forms in each view.