### PR TITLE
feat: Implement database reset functionality for super admins

### DIFF
--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -5,30 +5,40 @@ interface ModalProps {
   onClose: () => void;
   title?: string;
   children: React.ReactNode;
+  showCloseButton?: boolean; // Added this prop
 }
 
-const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  showCloseButton = true // Default to true
+}) => {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center">
-      <div className="relative mx-auto p-5 border w-full max-w-2xl shadow-lg rounded-md bg-white dark:bg-gray-800 overflow-y-auto max-h-[85vh]">
-        <div className="mt-3 text-center">
+    <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center px-4"> {/* Added px-4 for small screen padding */}
+      <div className="relative mx-auto p-5 sm:p-6 border w-full max-w-2xl shadow-lg rounded-md bg-white dark:bg-gray-800 overflow-y-auto max-h-[90vh]"> {/* Increased max-h, adjusted padding */}
+        <div className="text-center"> {/* Removed mt-3 */}
           {title && (
-            <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100">{title}</h3>
+            <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100 mb-4">{title}</h3>
           )}
-          <div className="mt-2 px-7 py-3">
+          {/* Changed text-center to text-left for form/children content consistency */}
+          <div className="text-left">
             {children}
           </div>
-          <div className="items-center px-4 py-3">
-            <button
-              id="ok-btn"
-              className="px-4 py-2 bg-gray-500 text-white text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-300"
-              onClick={onClose}
-            >
-              Close
-            </button>
-          </div>
+          {showCloseButton && ( // Conditionally render the close button section
+            <div className="items-center px-4 py-3 mt-5 sm:mt-6 border-t border-gray-200 dark:border-gray-700">
+              <button
+                id="modal-close-button" // Changed id for clarity
+                className="px-4 py-2 bg-gray-200 text-gray-800 dark:bg-gray-600 dark:text-gray-200 text-base font-medium rounded-md w-auto shadow-sm hover:bg-gray-300 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800"
+                onClick={onClose}
+              >
+                Close
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2397,6 +2397,59 @@ export async function superAdminCreateUser(userData: SuperAdminCreateUserPayload
 }
 // --- End Super Admin Create User ---
 
+// --- Super Admin Database Reset Functions ---
+export interface DatabaseResetStartResponse {
+  message: string;
+  backup_path: string;
+  log_file: string;
+}
+
+export async function startDatabaseReset(reason: string): Promise<DatabaseResetStartResponse> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/superadmin/database/reset/start`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
+      body: JSON.stringify({ reason }),
+    });
+    return handleApiError(response, 'Failed to start database reset process');
+  } catch (error: any) {
+    if (error instanceof TypeError && error.message.toLowerCase().includes('failed to fetch')) {
+      setGlobalOfflineStatus(true);
+      showErrorToast(OFFLINE_MESSAGE);
+    }
+    console.error('Error starting database reset:', error);
+    throw error;
+  }
+}
+
+export interface DatabaseResetConfirmPayload {
+  reset_password: string;
+  confirmation_text: string;
+}
+
+export interface DatabaseResetConfirmResponse {
+  message: string;
+}
+
+export async function confirmDatabaseReset(payload: DatabaseResetConfirmPayload): Promise<DatabaseResetConfirmResponse> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/superadmin/database/reset/confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
+      body: JSON.stringify(payload),
+    });
+    return handleApiError(response, 'Failed to confirm database reset');
+  } catch (error: any) {
+    if (error instanceof TypeError && error.message.toLowerCase().includes('failed to fetch')) {
+      setGlobalOfflineStatus(true);
+      showErrorToast(OFFLINE_MESSAGE);
+    }
+    console.error('Error confirming database reset:', error);
+    throw error;
+  }
+}
+// --- End Super Admin Database Reset Functions ---
+
 // --- Large File Upload (Chunked) ---
 
 /**


### PR DESCRIPTION
Adds a "Reset Database" feature to the Super Admin dashboard.

This feature includes:
- A multi-step confirmation process with several warnings to prevent accidental resets.
- A requirement for the super admin to provide a reason for the reset.
- Logging of the reset reason, user details (username, email, IP address), and timestamp to a dedicated file.
- Automatic backup of the current database before the reset operation.
- A final confirmation step requiring a specific password and confirmation text.
- Complete deletion of the database file and re-initialization from the schema, effectively resetting all data to its initial state.
- Comprehensive audit logging for all stages of the reset process, including IP addresses.

New API endpoints:
- POST /api/superadmin/database/reset/start
- POST /api/superadmin/database/reset/confirm

The UI in SuperAdminDashboard.tsx has been updated with a new section and modals to manage this flow. The backend in app.py now includes the new routes and logic for handling the reset process, including file logging, backup coordination, and database re-initialization.