### PR TITLE
Refactor: Standardize timestamp display to use your local time.

### DIFF
--- a/frontend/src/components/admin/versions/AdminVersionsTable.tsx
+++ b/frontend/src/components/admin/versions/AdminVersionsTable.tsx
@@ -70,7 +70,7 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
     if (!dateStr) return 'N/A';
     // Check if dateStr is a valid date string before creating a Date object
     const date = new Date(dateStr);
-    return !isNaN(date.getTime()) ? date.toLocaleDateString() : 'Invalid Date';
+    return !isNaN(date.getTime()) ? date.toLocaleString() : 'Invalid Date';
   };
 
   const truncateText = (text: string | null | undefined, maxLength: number = 50) => {

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -465,8 +465,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (d: DocumentType) => d.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (d: DocumentType) => d.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: (d: DocumentType) => d.created_at?new Date(d.created_at).toLocaleDateString('en-CA'):'-' },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (d: DocumentType) => d.updated_at?new Date(d.updated_at).toLocaleDateString('en-CA'):'-' },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (d: DocumentType) => d.created_at?new Date(d.created_at).toLocaleString():'-' },
+    { key: 'updated_at', header: 'Updated At', sortable: true, render: (d: DocumentType) => d.updated_at?new Date(d.updated_at).toLocaleString():'-' },
     { key: 'actions' as any, header: 'Actions', render: (d: DocumentType) => (
       <div className="flex space-x-1 items-center">
         {isAuthenticated && (

--- a/frontend/src/views/FavoritesView.tsx
+++ b/frontend/src/views/FavoritesView.tsx
@@ -224,7 +224,7 @@ const FavoritesView: React.FC = () => {
                     {item.version_number && ` • Version: ${item.version_number}`}
                   </p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Favorited on: {new Date(item.favorited_at).toLocaleDateString()}
+                    Favorited on: {new Date(item.favorited_at).toLocaleString()}
                   </p>
                 </div>
               </div>

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -343,8 +343,8 @@ const LinksView: React.FC = () => {
     },
     { key: 'uploaded_by_username', header: 'Added By', sortable: true, render: l => l.uploaded_by_username || 'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: l => l.updated_by_username || 'N/A' },
-    { key: 'created_at', header: 'Created', sortable: true, render: l => l.created_at ? new Date(l.created_at).toLocaleDateString('en-CA') : '-' },
-    { key: 'updated_at', header: 'Updated', sortable: true, render: l => l.updated_at ? new Date(l.updated_at).toLocaleDateString('en-CA') : '-' },
+    { key: 'created_at', header: 'Created', sortable: true, render: l => l.created_at ? new Date(l.created_at).toLocaleString() : '-' },
+    { key: 'updated_at', header: 'Updated', sortable: true, render: l => l.updated_at ? new Date(l.updated_at).toLocaleString() : '-' },
     {
       key: 'actions' as any,
       header: 'Actions',

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -260,7 +260,7 @@ const role = user?.role; // Access role safely, as user can be null
     finally { setIsMovingSelected(false); setModalSelectedCategoryId(null); }
   };
 
-  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleDateString('en-CA') : '-';
+  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleString() : '-';
   const formatFileSize = (bytes: number|null|undefined) => {
     if (bytes == null) return 'N/A';
     if (bytes === 0) return '0 B';

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -362,7 +362,7 @@ useEffect(() => {
     finally { setIsMovingSelected(false); setModalSelectedSoftwareId(null); setModalSelectedVersionId(null); }
   };
 
-  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleDateString('en-CA') : '-';
+  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleString() : '-';
   const columns: ColumnDef<PatchType>[] = [
     { key: 'patch_name', header: 'Patch Name', sortable: true }, { key: 'software_name', header: 'Software', sortable: true },
     { key: 'version_number', header: 'Version', sortable: true },


### PR DESCRIPTION
I updated various frontend components to use `toLocaleString()` for formatting timestamps. This ensures that where full date-time information is relevant (e.g., created_at, updated_at, release_date fields in tables, audit logs), it is displayed in your browser's local timezone and locale-specific format.

Previously, some views displayed only the date part (converted to local) or used other locale-specific formatting that included time. This change standardizes the approach for full timestamp visibility in local time across the affected views.

Affected views/components include:
- DocumentsView
- PatchesView
- LinksView
- MiscView
- AdminVersionsTable
- FavoritesView

Components like AuditLogViewer and AdminDashboardPage already used methods that displayed local date and time. Comment and Notification timestamps continue to use relative time formatting (e.g., "2 hours ago"), which is appropriate for those contexts.