### PR TITLE
feat: Display timestamps in IST with +05:30 offset in UI

### DIFF
--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -3,6 +3,7 @@ import { FiChevronDown, FiChevronUp, FiFilter, FiLoader, FiAlertTriangle } from 
 import { ListChecks as ListChecksIcon } from 'lucide-react'; // Added
 import { Box, Typography } from '@mui/material'; // Added
 import { fetchAuditLogEntries, AuditLogResponse, AuditLogEntry } from '../../services/api';
+import { formatISTWithOffset } from '../../utils'; // Updated import
 import { showErrorToast } from '../../utils/toastUtils'; // Import toast utility
 import LoadingState from '../LoadingState'; // For initial load
 import ErrorState from '../ErrorState'; // For initial load error
@@ -171,7 +172,7 @@ const AuditLogViewer: React.FC = () => {
                 ) : logs.length > 0 ? logs.map((log) => (
                   <tr key={log.id} className="hover:bg-gray-50 dark:hover:bg-gray-700">
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.id}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.timestamp ? new Date(log.timestamp).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: true }) : 'N/A'}</td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{formatISTWithOffset(log.timestamp)}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.user_id ?? 'N/A'}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.username ?? 'N/A'}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.action_type}</td>

--- a/frontend/src/components/admin/versions/AdminVersionsTable.tsx
+++ b/frontend/src/components/admin/versions/AdminVersionsTable.tsx
@@ -3,6 +3,7 @@ import { AdminSoftwareVersion, PaginationParams } from '../../../services/api'; 
 import { fetchAdminVersions } from '../../../services/api';
 import DataTable from '../../DataTable'; // Adjust path as needed
 import { FaEdit, FaTrash } from 'react-icons/fa';
+import { formatISTWithOffset, formatDateDisplay } from '../../../utils'; // Added imports
 
 interface AdminVersionsTableProps {
   onEdit: (version: AdminSoftwareVersion) => void;
@@ -66,12 +67,13 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
     setCurrentPage(1); // Reset to first page on sort change
   };
 
-  const formatNullableDate = (dateStr: string | null | undefined) => {
-    if (!dateStr) return 'N/A';
-    // Check if dateStr is a valid date string before creating a Date object
-    const date = new Date(dateStr);
-    return !isNaN(date.getTime()) ? date.toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : 'Invalid Date';
-  };
+  // formatNullableDate helper is no longer needed as we use specific utility functions now.
+  // const formatNullableDate = (dateStr: string | null | undefined) => {
+  //   if (!dateStr) return 'N/A';
+  //   // Check if dateStr is a valid date string before creating a Date object
+  //   const date = new Date(dateStr);
+  //   return !isNaN(date.getTime()) ? date.toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : 'Invalid Date';
+  // };
 
   const truncateText = (text: string | null | undefined, maxLength: number = 50) => {
     if (!text) return 'N/A';
@@ -83,7 +85,7 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
   const columns = [
     { key: 'software_name', header: 'Software', accessor: 'software_name', sortable: true },
     { key: 'version_number', header: 'Version', accessor: 'version_number', sortable: true },
-    { key: 'release_date', header: 'Release Date', accessor: 'release_date', sortable: true, render: (item: AdminSoftwareVersion) => formatNullableDate(item.release_date) },
+    { key: 'release_date', header: 'Release Date', accessor: 'release_date', sortable: true, Cell: ({ value }) => formatDateDisplay(value) },
     {
       key: 'main_download_link',
       header: 'Download Link',
@@ -98,8 +100,8 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
     },
     { key: 'changelog', header: 'Changelog', accessor: 'changelog', sortable: false, render: (item: AdminSoftwareVersion) => truncateText(item.changelog) },
     { key: 'known_bugs', header: 'Known Bugs', accessor: 'known_bugs', sortable: false, render: (item: AdminSoftwareVersion) => truncateText(item.known_bugs) },
-    { key: 'created_at', header: 'Created At', accessor: 'created_at', sortable: true, render: (item: AdminSoftwareVersion) => formatNullableDate(item.created_at) },
-    { key: 'updated_at', header: 'Updated At', accessor: 'updated_at', sortable: true, render: (item: AdminSoftwareVersion) => formatNullableDate(item.updated_at) },
+    { key: 'created_at', header: 'Created At', accessor: 'created_at', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
+    { key: 'updated_at', header: 'Updated At', accessor: 'updated_at', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
     {
       key: 'actions', // Unique key for the actions column
       header: 'Actions',

--- a/frontend/src/components/comments/Comment.tsx
+++ b/frontend/src/components/comments/Comment.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Comment as CommentType } from '../../services/api';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { MessageSquare, Edit3, Trash2, CornerDownRight } from 'lucide-react';
+import { formatISTWithOffset } from '../../utils'; // Added import
 
 interface CommentProps {
   comment: CommentType;
@@ -23,7 +24,7 @@ const Comment: React.FC<CommentProps> = ({ comment, onEdit, onDelete, onReply, c
       return formatDistanceToNow(parseISO(comment.created_at), { addSuffix: true });
     } catch (error) {
       console.error('Error formatting date:', error);
-      return comment.created_at; // Fallback to raw date
+      return formatISTWithOffset(comment.created_at); // Fallback to raw date, now formatted
     }
   };
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -1,0 +1,104 @@
+// frontend/src/utils/dateUtils.ts
+export function formatDateDisplay(dateString: string | null | undefined): string {
+  if (!dateString) {
+    return 'N/A';
+  }
+  try {
+    // Assuming dateString is 'YYYY-MM-DD' and represents a specific day.
+    // Create date as UTC to avoid timezone shifts during parsing by `new Date()`.
+    const parts = dateString.split('-');
+    if (parts.length !== 3) return 'Invalid Date Input';
+
+    const year = parseInt(parts[0], 10);
+    const month = parseInt(parts[1], 10); // 1-12
+    const day = parseInt(parts[2], 10);
+
+    if (isNaN(year) || isNaN(month) || isNaN(day)) {
+        return 'Invalid Date Parts';
+    }
+
+    // Create a new Date object treating the input as calendar date components.
+    // Date.UTC expects month to be 0-11.
+    const date = new Date(Date.UTC(year, month - 1, day));
+
+    return date.toLocaleDateString('en-IN', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      timeZone: 'UTC', // Format the UTC date as is, without converting to local system time.
+    });
+  } catch (e) {
+    console.error('Error formatting date display:', dateString, e);
+    return 'Invalid Date';
+  }
+}
+
+export function formatISTWithOffset(isoTimestamp: string): string {
+  if (!isoTimestamp) {
+    return 'N/A';
+  }
+
+  try {
+    const date = new Date(isoTimestamp); // Correctly parses "YYYY-MM-DDTHH:MM:SS+05:30"
+
+    // Format date and time parts using 'en-IN' locale and IST timezone.
+    // This ensures the date/time values are correct for IST.
+    const dateOptions: Intl.DateTimeFormatOptions = {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      timeZone: 'Asia/Kolkata', // Ensure interpretation as IST
+    };
+    const timeOptions: Intl.DateTimeFormatOptions = {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: true, // Or false for 24-hour format
+      timeZone: 'Asia/Kolkata', // Ensure interpretation as IST
+    };
+
+    const datePart = date.toLocaleDateString('en-IN', dateOptions); // e.g., "27/10/2023"
+    const timePart = date.toLocaleTimeString('en-IN', timeOptions); // e.g., "10:00:00 AM"
+
+    // The input isoTimestamp already contains the offset. We can extract it,
+    // or, since we are standardizing on IST, we can hardcode "+05:30".
+    // Extracting it to be robust, though for this project it will always be +05:30 from backend.
+    const offsetMatch = isoTimestamp.match(/[+-]\d{2}:\d{2}$/);
+    const offsetString = offsetMatch ? offsetMatch[0] : '+05:30'; // Default to +05:30
+
+    return `${datePart}, ${timePart} ${offsetString}`; // e.g., "27/10/2023, 10:00:00 AM +05:30"
+  } catch (error) {
+    console.error('Error formatting timestamp:', isoTimestamp, error);
+    // Check if the original string was "Invalid Date" or similar from backend already
+    if (typeof isoTimestamp === 'string' && isoTimestamp.toLowerCase().includes('invalid date')) {
+        return isoTimestamp;
+    }
+    return 'Invalid Date'; // Fallback for other invalid timestamps
+  }
+}
+
+// Utility to format just the date part in YYYY-MM-DD for input fields
+export function formatDateForInput(isoTimestamp: string | null | undefined): string {
+  if (!isoTimestamp) {
+    return '';
+  }
+  try {
+    const date = new Date(isoTimestamp);
+    // Adjust for timezone offset to get the correct date in 'Asia/Kolkata'
+    // then format as YYYY-MM-DD
+
+    // Create a new date object that represents the date in IST.
+    // Date.toLocaleDateString with specific options can give parts, but direct formatting is easier.
+    // We need to be careful: `new Date(isoTimestamp)` creates a Date object whose internal value is UTC.
+    // `getFullYear`, `getMonth`, `getDate` operate on the *local* time of the system running the JS.
+    // To get the correct YYYY-MM-DD for IST from an IST-offsetted ISO string:
+    const year = date.toLocaleDateString('en-US', { year: 'numeric', timeZone: 'Asia/Kolkata' });
+    const month = date.toLocaleDateString('en-US', { month: '2-digit', timeZone: 'Asia/Kolkata' });
+    const day = date.toLocaleDateString('en-US', { day: '2-digit', timeZone: 'Asia/Kolkata' });
+
+    return `${year}-${month}-${day}`;
+  } catch (error) {
+    console.error('Error formatting date for input:', isoTimestamp, error);
+    return '';
+  }
+}

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,3 @@
+// frontend/src/utils/index.ts
+export * from './dateUtils';
+// Add other utils here if any

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -15,7 +15,8 @@ import {
   BulkItemType,
 } from '../services/api'; 
 import { Document as DocumentType, Software } from '../types'; 
-import DataTable, { ColumnDef } from '../components/DataTable'; 
+import DataTable, { ColumnDef } from '../components/DataTable';
+import { formatISTWithOffset } from '../utils'; // Added import
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState'; 
 import ErrorState from '../components/ErrorState';
@@ -465,8 +466,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (d: DocumentType) => d.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (d: DocumentType) => d.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: (d: DocumentType) => d.created_at ? new Date(d.created_at).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-' },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (d: DocumentType) => d.updated_at ? new Date(d.updated_at).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-' },
+    { key: 'created_at', header: 'Created At', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
     { key: 'actions' as any, header: 'Actions', render: (d: DocumentType) => (
       <div className="flex space-x-1 items-center">
         {isAuthenticated && (

--- a/frontend/src/views/FavoritesView.tsx
+++ b/frontend/src/views/FavoritesView.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../context/AuthContext';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils'; // Import toast utilities
+import { formatISTWithOffset } from '../utils'; // Added import
 
 const FavoritesView: React.FC = () => {
   const { isAuthenticated, isLoading: isAuthLoading } = useAuth(); // Renamed to avoid conflict
@@ -224,7 +225,7 @@ const FavoritesView: React.FC = () => {
                     {item.version_number && ` • Version: ${item.version_number}`}
                   </p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Favorited on: {new Date(item.favorited_at).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })}
+                    Favorited on: {formatISTWithOffset(item.favorited_at)}
                   </p>
                 </div>
               </div>

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -9,6 +9,7 @@ import {
 import { Link as LinkType, Software, SoftwareVersion } from '../types'; // LinkType is already here
 import CommentSection from '../components/comments/CommentSection'; // Added CommentSection
 import DataTable, { ColumnDef } from '../components/DataTable';
+import { formatISTWithOffset } from '../utils'; // Added import
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
@@ -343,8 +344,8 @@ const LinksView: React.FC = () => {
     },
     { key: 'uploaded_by_username', header: 'Added By', sortable: true, render: l => l.uploaded_by_username || 'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: l => l.updated_by_username || 'N/A' },
-    { key: 'created_at', header: 'Created', sortable: true, render: l => l.created_at ? new Date(l.created_at).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-' },
-    { key: 'updated_at', header: 'Updated', sortable: true, render: l => l.updated_at ? new Date(l.updated_at).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-' },
+    { key: 'created_at', header: 'Created', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
+    { key: 'updated_at', header: 'Updated', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
     {
       key: 'actions' as any,
       header: 'Actions',

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -10,6 +10,7 @@ import {
 import { MiscCategory, MiscFile } from '../types'; // MiscFile is already here
 import CommentSection from '../components/comments/CommentSection'; // Added CommentSection
 import DataTable, { ColumnDef } from '../components/DataTable';
+import { formatISTWithOffset } from '../utils'; // Added import
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import AdminUploadToMiscForm from '../components/admin/AdminUploadToMiscForm'; // Using the correct form name
@@ -260,7 +261,13 @@ const role = user?.role; // Access role safely, as user can be null
     finally { setIsMovingSelected(false); setModalSelectedCategoryId(null); }
   };
 
-  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-';
+  // formatDate helper is no longer needed as we use the utility function directly in columns.
+  // However, if it were used for both created_at and updated_at which are not present in this file's column defs,
+  // it would be modified. Let's assume created_at and updated_at are handled directly or this helper is for specific date-only fields if any.
+  // For this task, the relevant column is 'created_at' which is 'Uploaded At'.
+  // If other timestamp columns like 'updated_at' were present, they'd also use formatISTWithOffset.
+
+  // const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-';
   const formatFileSize = (bytes: number|null|undefined) => {
     if (bytes == null) return 'N/A';
     if (bytes === 0) return '0 B';
@@ -275,7 +282,9 @@ const role = user?.role; // Access role safely, as user can be null
     { key: 'category_name', header: 'Category', sortable: true },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: f => f.uploaded_by_username||'N/A' },
     { key: 'file_size', header: 'Size', sortable: true, render: f => formatFileSize(f.file_size) },
-    { key: 'created_at', header: 'Uploaded At', sortable: true, render: f => formatDate(f.created_at) },
+    { key: 'created_at', header: 'Uploaded At', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
+    // Assuming there's an updated_at field that might be added later or is implicitly handled by a similar pattern.
+    // For now, only created_at is explicitly in the provided column defs.
     { 
       key: 'file_path', 
       header: 'Link', 

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -19,6 +19,7 @@ import {
 import { Patch as PatchType, Software, SoftwareVersion } from '../types';
 import CommentSection from '../components/comments/CommentSection'; // Added CommentSection
 import DataTable, { ColumnDef } from '../components/DataTable';
+import { formatISTWithOffset, formatDateDisplay } from '../utils'; // Added imports
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
@@ -362,13 +363,13 @@ useEffect(() => {
     finally { setIsMovingSelected(false); setModalSelectedSoftwareId(null); setModalSelectedVersionId(null); }
   };
 
-  const formatDate = (dateStr: string | null | undefined) => dateStr ? new Date(dateStr).toLocaleString('en-IN', { timeZone: 'Asia/Kolkata', day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true }) : '-';
+  // const formatDate helper is no longer needed as we use specific utility functions now.
   const columns: ColumnDef<PatchType>[] = [
     { key: 'patch_name', header: 'Patch Name', sortable: true }, { key: 'software_name', header: 'Software', sortable: true },
     { key: 'version_number', header: 'Version', sortable: true },
     { key: 'patch_by_developer', header: 'Developer', sortable: true, render: p => p.patch_by_developer || '-' },
     { key: 'description', header: 'Description', render: p => <span className="text-sm text-gray-600 block max-w-xs truncate" title={p.description||''}>{p.description||'-'}</span> },
-    { key: 'release_date', header: 'Release Date', sortable: true, render: p => formatDate(p.release_date) },
+    { key: 'release_date', header: 'Release Date', sortable: true, Cell: ({ value }) => formatDateDisplay(value) },
     { 
       key: 'download_link', 
       header: 'Link', 
@@ -400,8 +401,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: p => p.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: p => p.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: p => formatDate(p.created_at) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: p => formatDate(p.updated_at) },
+    { key: 'created_at', header: 'Created At', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, Cell: ({ value }) => formatISTWithOffset(value) },
     { 
       key: 'actions' as any, 
       header: 'Actions', 


### PR DESCRIPTION
Implemented new frontend utility functions `formatISTWithOffset` and `formatDateDisplay` to standardize timestamp and date presentation.

- `formatISTWithOffset` takes an ISO 8601 string (with +05:30 offset from the backend) and formats it to 'DD/MM/YYYY, HH:MM:SS AM/PM +05:30'.
- `formatDateDisplay` formats 'YYYY-MM-DD' date strings to 'DD/MM/YYYY'.

These utilities have been applied to various components including AuditLogViewer, DocumentsView, PatchesView, LinksView, MiscView, AdminVersionsTable, FavoritesView, and CommentItem to ensure consistent IST display with the specified offset style.

This change aligns the UI display with your requirements for IST timestamps and enhances clarity by explicitly showing the offset.