### PR TITLE
fix: Use 'render' prop for custom table cell content

### DIFF
--- a/frontend/src/components/admin/versions/AdminVersionsTable.tsx
+++ b/frontend/src/components/admin/versions/AdminVersionsTable.tsx
@@ -85,7 +85,7 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
   const columns = [
     { key: 'software_name', header: 'Software', accessor: 'software_name', sortable: true },
     { key: 'version_number', header: 'Version', accessor: 'version_number', sortable: true },
-    { key: 'release_date', header: 'Release Date', accessor: 'release_date', sortable: true, cell: (info) => formatDateDisplay(info.getValue() as string) },
+    { key: 'release_date', header: 'Release Date', accessor: 'release_date', sortable: true, render: (item: AdminSoftwareVersion) => formatDateDisplay(item.release_date) },
     {
       key: 'main_download_link',
       header: 'Download Link',
@@ -100,8 +100,8 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
     },
     { key: 'changelog', header: 'Changelog', accessor: 'changelog', sortable: false, render: (item: AdminSoftwareVersion) => truncateText(item.changelog) },
     { key: 'known_bugs', header: 'Known Bugs', accessor: 'known_bugs', sortable: false, render: (item: AdminSoftwareVersion) => truncateText(item.known_bugs) },
-    { key: 'created_at', header: 'Created At', accessor: 'created_at', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
-    { key: 'updated_at', header: 'Updated At', accessor: 'updated_at', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
+    { key: 'created_at', header: 'Created At', accessor: 'created_at', sortable: true, render: (item: AdminSoftwareVersion) => formatISTWithOffset(item.created_at) },
+    { key: 'updated_at', header: 'Updated At', accessor: 'updated_at', sortable: true, render: (item: AdminSoftwareVersion) => formatISTWithOffset(item.updated_at) },
     {
       key: 'actions', // Unique key for the actions column
       header: 'Actions',

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -466,8 +466,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (d: DocumentType) => d.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (d: DocumentType) => d.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (item: DocumentType) => formatISTWithOffset(item.created_at) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: DocumentType) => formatISTWithOffset(item.updated_at) },
     { key: 'actions' as any, header: 'Actions', render: (d: DocumentType) => (
       <div className="flex space-x-1 items-center">
         {isAuthenticated && (

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -344,8 +344,8 @@ const LinksView: React.FC = () => {
     },
     { key: 'uploaded_by_username', header: 'Added By', sortable: true, render: l => l.uploaded_by_username || 'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: l => l.updated_by_username || 'N/A' },
-    { key: 'created_at', header: 'Created', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
-    { key: 'updated_at', header: 'Updated', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
+    { key: 'created_at', header: 'Created', sortable: true, render: (item: LinkType) => formatISTWithOffset(item.created_at) },
+    { key: 'updated_at', header: 'Updated', sortable: true, render: (item: LinkType) => formatISTWithOffset(item.updated_at) },
     {
       key: 'actions' as any,
       header: 'Actions',

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -282,7 +282,7 @@ const role = user?.role; // Access role safely, as user can be null
     { key: 'category_name', header: 'Category', sortable: true },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: f => f.uploaded_by_username||'N/A' },
     { key: 'file_size', header: 'Size', sortable: true, render: f => formatFileSize(f.file_size) },
-    { key: 'created_at', header: 'Uploaded At', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
+    { key: 'created_at', header: 'Uploaded At', sortable: true, render: (item: MiscFile) => formatISTWithOffset(item.created_at) },
     // Assuming there's an updated_at field that might be added later or is implicitly handled by a similar pattern.
     // For now, only created_at is explicitly in the provided column defs.
     { 

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -369,7 +369,7 @@ useEffect(() => {
     { key: 'version_number', header: 'Version', sortable: true },
     { key: 'patch_by_developer', header: 'Developer', sortable: true, render: p => p.patch_by_developer || '-' },
     { key: 'description', header: 'Description', render: p => <span className="text-sm text-gray-600 block max-w-xs truncate" title={p.description||''}>{p.description||'-'}</span> },
-    { key: 'release_date', header: 'Release Date', sortable: true, cell: (info) => formatDateDisplay(info.getValue() as string) },
+    { key: 'release_date', header: 'Release Date', sortable: true, render: (item: PatchType) => formatDateDisplay(item.release_date) },
     { 
       key: 'download_link', 
       header: 'Link', 
@@ -401,8 +401,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: p => p.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: p => p.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, cell: (info) => formatISTWithOffset(info.getValue() as string) },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (item: PatchType) => formatISTWithOffset(item.created_at) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: PatchType) => formatISTWithOffset(item.updated_at) },
     { 
       key: 'actions' as any, 
       header: 'Actions', 


### PR DESCRIPTION
Corrected the custom cell rendering in components using the project's `DataTable` component (`DocumentsView`, `PatchesView`, `LinksView`, `MiscView`, `AdminVersionsTable`).

The custom `ColumnDef` in `DataTable.tsx` expects a `render` property (e.g., `render: (item: RowDataType) => node`) for custom cell content, not `cell` or `Cell` as in standard TanStack Table.

This change updates the column definitions to use the correct `render` syntax, passing the entire row item to the render function and accessing properties directly (e.g., `item.created_at`).

This resolves the following TypeScript errors:
- "Object literal may only specify known properties, and 'cell' does not exist in type 'ColumnDef'."
- "Parameter 'info' implicitly has an 'any' type."

Timestamp and date formatting functions (`formatISTWithOffset` and `formatDateDisplay`) continue to be applied correctly within the `render` methods.