### PR TITLE
fix: Display IST timestamps in standard locale format

### DIFF
--- a/frontend/src/components/admin/AuditLogViewer.tsx
+++ b/frontend/src/components/admin/AuditLogViewer.tsx
@@ -3,7 +3,7 @@ import { FiChevronDown, FiChevronUp, FiFilter, FiLoader, FiAlertTriangle } from 
 import { ListChecks as ListChecksIcon } from 'lucide-react'; // Added
 import { Box, Typography } from '@mui/material'; // Added
 import { fetchAuditLogEntries, AuditLogResponse, AuditLogEntry } from '../../services/api';
-import { formatISTWithOffset } from '../../utils'; // Updated import
+import { formatToISTLocaleString } from '../../utils'; // Updated import
 import { showErrorToast } from '../../utils/toastUtils'; // Import toast utility
 import LoadingState from '../LoadingState'; // For initial load
 import ErrorState from '../ErrorState'; // For initial load error
@@ -178,8 +178,8 @@ const AuditLogViewer: React.FC = () => {
                     {/* If this table were to be refactored to use TanStack's useReactTable, then the Cell prop would apply. */}
                     {/* The prompt seems to assume this is a TanStack Table 'columns' def, but it's a manual table build. */}
                     {/* No change needed here unless the table structure is misunderstood by the prompt. */}
-                    {/* However, if the intent was to ensure formatISTWithOffset is used, it already is. */}
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{formatISTWithOffset(log.timestamp)}</td>
+                    {/* However, if the intent was to ensure formatToISTLocaleString is used, it already is. */}
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{formatToISTLocaleString(log.timestamp)}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.user_id ?? 'N/A'}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.username ?? 'N/A'}</td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-300">{log.action_type}</td>

--- a/frontend/src/components/admin/versions/AdminVersionsTable.tsx
+++ b/frontend/src/components/admin/versions/AdminVersionsTable.tsx
@@ -3,7 +3,7 @@ import { AdminSoftwareVersion, PaginationParams } from '../../../services/api'; 
 import { fetchAdminVersions } from '../../../services/api';
 import DataTable from '../../DataTable'; // Adjust path as needed
 import { FaEdit, FaTrash } from 'react-icons/fa';
-import { formatISTWithOffset, formatDateDisplay } from '../../../utils'; // Added imports
+import { formatToISTLocaleString, formatDateDisplay } from '../../../utils'; // Updated import
 
 interface AdminVersionsTableProps {
   onEdit: (version: AdminSoftwareVersion) => void;
@@ -85,7 +85,7 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
   const columns = [
     { key: 'software_name', header: 'Software', accessor: 'software_name', sortable: true },
     { key: 'version_number', header: 'Version', accessor: 'version_number', sortable: true },
-    { key: 'release_date', header: 'Release Date', accessor: 'release_date', sortable: true, render: (item: AdminSoftwareVersion) => formatDateDisplay(item.release_date) },
+    { key: 'release_date', header: 'Release Date', accessor: 'release_date', sortable: true, render: (item: AdminSoftwareVersion) => formatDateDisplay(item.release_date) }, // Stays the same
     {
       key: 'main_download_link',
       header: 'Download Link',
@@ -100,8 +100,8 @@ const AdminVersionsTable: React.FC<AdminVersionsTableProps> = ({ onEdit, onDelet
     },
     { key: 'changelog', header: 'Changelog', accessor: 'changelog', sortable: false, render: (item: AdminSoftwareVersion) => truncateText(item.changelog) },
     { key: 'known_bugs', header: 'Known Bugs', accessor: 'known_bugs', sortable: false, render: (item: AdminSoftwareVersion) => truncateText(item.known_bugs) },
-    { key: 'created_at', header: 'Created At', accessor: 'created_at', sortable: true, render: (item: AdminSoftwareVersion) => formatISTWithOffset(item.created_at) },
-    { key: 'updated_at', header: 'Updated At', accessor: 'updated_at', sortable: true, render: (item: AdminSoftwareVersion) => formatISTWithOffset(item.updated_at) },
+    { key: 'created_at', header: 'Created At', accessor: 'created_at', sortable: true, render: (item: AdminSoftwareVersion) => formatToISTLocaleString(item.created_at) },
+    { key: 'updated_at', header: 'Updated At', accessor: 'updated_at', sortable: true, render: (item: AdminSoftwareVersion) => formatToISTLocaleString(item.updated_at) },
     {
       key: 'actions', // Unique key for the actions column
       header: 'Actions',

--- a/frontend/src/components/comments/Comment.tsx
+++ b/frontend/src/components/comments/Comment.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Comment as CommentType } from '../../services/api';
 import { formatDistanceToNow, parseISO } from 'date-fns';
 import { MessageSquare, Edit3, Trash2, CornerDownRight } from 'lucide-react';
-import { formatISTWithOffset } from '../../utils'; // Added import
+import { formatToISTLocaleString } from '../../utils'; // Updated import
 
 interface CommentProps {
   comment: CommentType;
@@ -24,7 +24,7 @@ const Comment: React.FC<CommentProps> = ({ comment, onEdit, onDelete, onReply, c
       return formatDistanceToNow(parseISO(comment.created_at), { addSuffix: true });
     } catch (error) {
       console.error('Error formatting date:', error);
-      return formatISTWithOffset(comment.created_at); // Fallback to raw date, now formatted
+      return formatToISTLocaleString(comment.created_at); // Fallback to raw date, now formatted
     }
   };
 

--- a/frontend/src/utils/dateUtils.ts
+++ b/frontend/src/utils/dateUtils.ts
@@ -33,7 +33,7 @@ export function formatDateDisplay(dateString: string | null | undefined): string
   }
 }
 
-export function formatISTWithOffset(isoTimestamp: string): string {
+export function formatToISTLocaleString(isoTimestamp: string): string {
   if (!isoTimestamp) {
     return 'N/A';
   }
@@ -42,33 +42,20 @@ export function formatISTWithOffset(isoTimestamp: string): string {
     const date = new Date(isoTimestamp); // Correctly parses "YYYY-MM-DDTHH:MM:SS+05:30"
 
     // Format date and time parts using 'en-IN' locale and IST timezone.
-    // This ensures the date/time values are correct for IST.
-    const dateOptions: Intl.DateTimeFormatOptions = {
+    const options: Intl.DateTimeFormatOptions = {
       day: '2-digit',
       month: '2-digit',
       year: 'numeric',
-      timeZone: 'Asia/Kolkata', // Ensure interpretation as IST
-    };
-    const timeOptions: Intl.DateTimeFormatOptions = {
       hour: '2-digit',
       minute: '2-digit',
       second: '2-digit',
-      hour12: true, // Or false for 24-hour format
-      timeZone: 'Asia/Kolkata', // Ensure interpretation as IST
+      hour12: true,
+      timeZone: 'Asia/Kolkata', // Ensures the output is IST
     };
 
-    const datePart = date.toLocaleDateString('en-IN', dateOptions); // e.g., "27/10/2023"
-    const timePart = date.toLocaleTimeString('en-IN', timeOptions); // e.g., "10:00:00 AM"
-
-    // The input isoTimestamp already contains the offset. We can extract it,
-    // or, since we are standardizing on IST, we can hardcode "+05:30".
-    // Extracting it to be robust, though for this project it will always be +05:30 from backend.
-    const offsetMatch = isoTimestamp.match(/[+-]\d{2}:\d{2}$/);
-    const offsetString = offsetMatch ? offsetMatch[0] : '+05:30'; // Default to +05:30
-
-    return `${datePart}, ${timePart} ${offsetString}`; // e.g., "27/10/2023, 10:00:00 AM +05:30"
+    return date.toLocaleString('en-IN', options); // e.g., "dd/mm/yyyy, h:mm:ss AM/PM"
   } catch (error) {
-    console.error('Error formatting timestamp:', isoTimestamp, error);
+    console.error('Error formatting timestamp to IST locale string:', isoTimestamp, error);
     // Check if the original string was "Invalid Date" or similar from backend already
     if (typeof isoTimestamp === 'string' && isoTimestamp.toLowerCase().includes('invalid date')) {
         return isoTimestamp;

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -16,7 +16,7 @@ import {
 } from '../services/api'; 
 import { Document as DocumentType, Software } from '../types'; 
 import DataTable, { ColumnDef } from '../components/DataTable';
-import { formatISTWithOffset } from '../utils'; // Added import
+import { formatToISTLocaleString } from '../utils'; // Updated import
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState'; 
 import ErrorState from '../components/ErrorState';
@@ -466,8 +466,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (d: DocumentType) => d.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (d: DocumentType) => d.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: (item: DocumentType) => formatISTWithOffset(item.created_at) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: DocumentType) => formatISTWithOffset(item.updated_at) },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (item: DocumentType) => formatToISTLocaleString(item.created_at) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: DocumentType) => formatToISTLocaleString(item.updated_at) },
     { key: 'actions' as any, header: 'Actions', render: (d: DocumentType) => (
       <div className="flex space-x-1 items-center">
         {isAuthenticated && (

--- a/frontend/src/views/FavoritesView.tsx
+++ b/frontend/src/views/FavoritesView.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '../context/AuthContext';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils'; // Import toast utilities
-import { formatISTWithOffset } from '../utils'; // Added import
+import { formatToISTLocaleString } from '../utils'; // Updated import
 
 const FavoritesView: React.FC = () => {
   const { isAuthenticated, isLoading: isAuthLoading } = useAuth(); // Renamed to avoid conflict
@@ -225,7 +225,7 @@ const FavoritesView: React.FC = () => {
                     {item.version_number && ` • Version: ${item.version_number}`}
                   </p>
                   <p className="text-xs text-gray-500 dark:text-gray-400">
-                    Favorited on: {formatISTWithOffset(item.favorited_at as string)}
+                    Favorited on: {formatToISTLocaleString(item.favorited_at as string)}
                   </p>
                 </div>
               </div>

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -9,7 +9,7 @@ import {
 import { Link as LinkType, Software, SoftwareVersion } from '../types'; // LinkType is already here
 import CommentSection from '../components/comments/CommentSection'; // Added CommentSection
 import DataTable, { ColumnDef } from '../components/DataTable';
-import { formatISTWithOffset } from '../utils'; // Added import
+import { formatToISTLocaleString } from '../utils'; // Updated import
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
@@ -344,8 +344,8 @@ const LinksView: React.FC = () => {
     },
     { key: 'uploaded_by_username', header: 'Added By', sortable: true, render: l => l.uploaded_by_username || 'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: l => l.updated_by_username || 'N/A' },
-    { key: 'created_at', header: 'Created', sortable: true, render: (item: LinkType) => formatISTWithOffset(item.created_at) },
-    { key: 'updated_at', header: 'Updated', sortable: true, render: (item: LinkType) => formatISTWithOffset(item.updated_at) },
+    { key: 'created_at', header: 'Created', sortable: true, render: (item: LinkType) => formatToISTLocaleString(item.created_at) },
+    { key: 'updated_at', header: 'Updated', sortable: true, render: (item: LinkType) => formatToISTLocaleString(item.updated_at) },
     {
       key: 'actions' as any,
       header: 'Actions',

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -10,7 +10,7 @@ import {
 import { MiscCategory, MiscFile } from '../types'; // MiscFile is already here
 import CommentSection from '../components/comments/CommentSection'; // Added CommentSection
 import DataTable, { ColumnDef } from '../components/DataTable';
-import { formatISTWithOffset } from '../utils'; // Added import
+import { formatToISTLocaleString } from '../utils'; // Updated import
 import ErrorState from '../components/ErrorState';
 import LoadingState from '../components/LoadingState';
 import AdminUploadToMiscForm from '../components/admin/AdminUploadToMiscForm'; // Using the correct form name
@@ -282,7 +282,7 @@ const role = user?.role; // Access role safely, as user can be null
     { key: 'category_name', header: 'Category', sortable: true },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: f => f.uploaded_by_username||'N/A' },
     { key: 'file_size', header: 'Size', sortable: true, render: f => formatFileSize(f.file_size) },
-    { key: 'created_at', header: 'Uploaded At', sortable: true, render: (item: MiscFile) => formatISTWithOffset(item.created_at) },
+    { key: 'created_at', header: 'Uploaded At', sortable: true, render: (item: MiscFile) => formatToISTLocaleString(item.created_at) },
     // Assuming there's an updated_at field that might be added later or is implicitly handled by a similar pattern.
     // For now, only created_at is explicitly in the provided column defs.
     { 

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -19,7 +19,7 @@ import {
 import { Patch as PatchType, Software, SoftwareVersion } from '../types';
 import CommentSection from '../components/comments/CommentSection'; // Added CommentSection
 import DataTable, { ColumnDef } from '../components/DataTable';
-import { formatISTWithOffset, formatDateDisplay } from '../utils'; // Added imports
+import { formatToISTLocaleString, formatDateDisplay } from '../utils'; // Updated import
 import FilterTabs from '../components/FilterTabs';
 import LoadingState from '../components/LoadingState';
 import ErrorState from '../components/ErrorState';
@@ -369,7 +369,7 @@ useEffect(() => {
     { key: 'version_number', header: 'Version', sortable: true },
     { key: 'patch_by_developer', header: 'Developer', sortable: true, render: p => p.patch_by_developer || '-' },
     { key: 'description', header: 'Description', render: p => <span className="text-sm text-gray-600 block max-w-xs truncate" title={p.description||''}>{p.description||'-'}</span> },
-    { key: 'release_date', header: 'Release Date', sortable: true, render: (item: PatchType) => formatDateDisplay(item.release_date) },
+    { key: 'release_date', header: 'Release Date', sortable: true, render: (item: PatchType) => formatDateDisplay(item.release_date) }, // Stays the same
     { 
       key: 'download_link', 
       header: 'Link', 
@@ -401,8 +401,8 @@ useEffect(() => {
     },
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: p => p.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: p => p.updated_by_username||'N/A' },
-    { key: 'created_at', header: 'Created At', sortable: true, render: (item: PatchType) => formatISTWithOffset(item.created_at) },
-    { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: PatchType) => formatISTWithOffset(item.updated_at) },
+    { key: 'created_at', header: 'Created At', sortable: true, render: (item: PatchType) => formatToISTLocaleString(item.created_at) },
+    { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: PatchType) => formatToISTLocaleString(item.updated_at) },
     { 
       key: 'actions' as any, 
       header: 'Actions', 


### PR DESCRIPTION
Updated the frontend timestamp formatting utility `formatToISTLocaleString` (previously `formatISTWithOffset`) to display timestamps in IST using Indian locale conventions (`en-IN`) without explicitly appending the "+05:30" numerical offset string.

The function now leverages `Date.prototype.toLocaleString()` with the `timeZone: 'Asia/Kolkata'` option to achieve the correct IST value and standard locale presentation.

This change addresses your feedback requesting a cleaner display of IST times, ensuring the time value is IST while the presentation is natural for the specified locale. Components previously using the old formatter have been updated.