### PR TITLE
fix: Store and display audit log timestamps in IST

### DIFF
--- a/app.py
+++ b/app.py
@@ -561,7 +561,7 @@ def log_audit_action(action_type: str, target_table: str = None, target_id: int 
         db = get_db()
         db.execute("""
             INSERT INTO audit_logs (user_id, username, action_type, target_table, target_id, details, timestamp)
-            VALUES (?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%d %H:%M:%S', 'now', '+05:30'))
         """, (final_user_id, final_username, action_type, target_table, target_id, details_json))
         db.commit()
     except sqlite3.Error as e_db:


### PR DESCRIPTION
Modified the `log_audit_action` function in `app.py` to store audit log timestamps as naive datetime strings representing IST (using `strftime('%Y-%m-%d %H:%M:%S', 'now', '+05:30')`). Previously, timestamps were stored as naive UTC strings.

This change ensures that the `convert_timestamps_to_ist_iso` helper function correctly interprets these timestamps as IST, generates the appropriate ISO 8601 string with the +05:30 offset, and allows the frontend to display them accurately in IST.

This resolves an inconsistency where audit logs were appearing in UTC while other parts of the application correctly showed IST. Existing audit log entries will retain their original stored times.