### PR TITLE
Style: Align modals to the top of the viewport

### DIFF
--- a/frontend/src/components/shared/ConfirmationModal.tsx
+++ b/frontend/src/components/shared/ConfirmationModal.tsx
@@ -38,8 +38,8 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
 
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 transition-opacity">
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-md transform transition-all">
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black bg-opacity-50 transition-opacity pt-12"> {/* Changed items-center to items-start and added pt-12 to this wrapper */}
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-md transform transition-all"> {/* No margin needed here as padding on parent pushes it down */}
         <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">{title}</h3>
         <div className="mt-2">
           {typeof message === 'string' ? <p className="text-sm text-gray-500 dark:text-gray-300">{message}</p> : message}

--- a/frontend/src/components/shared/Modal.tsx
+++ b/frontend/src/components/shared/Modal.tsx
@@ -18,8 +18,8 @@ const Modal: React.FC<ModalProps> = ({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-center px-4"> {/* Added px-4 for small screen padding */}
-      <div className="relative mx-auto p-4 sm:p-5 border w-full max-w-2xl shadow-lg rounded-md bg-white dark:bg-gray-800 overflow-y-auto max-h-[90vh]"> {/* Increased max-h, adjusted padding */}
+    <div className="fixed inset-0 bg-black bg-opacity-50 overflow-y-auto h-full w-full z-50 flex justify-center items-start px-4 pt-12"> {/* Changed items-center to items-start, added pt-12 */}
+      <div className="relative mx-auto p-4 sm:p-5 border w-full max-w-2xl shadow-lg rounded-md bg-white dark:bg-gray-800 overflow-y-auto max-h-[calc(90vh-3rem)]"> {/* Adjusted max-h to account for pt-12. 3rem is 48px. */}
         <div className="text-center"> {/* Removed mt-3 */}
           {title && (
             <h3 className="text-lg leading-6 font-medium text-gray-900 dark:text-gray-100 mb-4">{title}</h3>


### PR DESCRIPTION
This commit updates the vertical alignment of modals to position them nearer to the top of the viewport, rather than being strictly centered. This can improve your experience for modals with taller content.

Changes:
- In `frontend/src/components/shared/Modal.tsx`:
  - Changed the flex wrapper from `items-center` to `items-start`.
  - Added `pt-12` (padding-top) to the flex wrapper to create space above the modal.
  - Adjusted `max-h-[90vh]` to `max-h-[calc(90vh-3rem)]` for the modal content area to account for the new top padding, ensuring the effective maximum height remains consistent with the viewport.

- In `frontend/src/components/shared/ConfirmationModal.tsx`:
  - Changed the flex wrapper from `items-center` to `items-start`.
  - Added `pt-12` (padding-top) to the flex wrapper.

These changes ensure that both primary and confirmation modals are consistently aligned to the top. I've outlined manual testing steps to verify the new positioning on various screen heights.