### PR TITLE
Feat: Disable Deactivate/Permissions buttons for primary super admin

### DIFF
--- a/frontend/src/views/SuperAdminDashboard.tsx
+++ b/frontend/src/views/SuperAdminDashboard.tsx
@@ -706,7 +706,7 @@ const SuperAdminDashboard: React.FC = () => {
       render: (user) => {
         const isCurrentUser = auth.user?.id === user.id;
         const isFirstSA = user.id === firstSuperAdminId;
-        const isOnlyActiveSuperAdmin = auth.user?.username === user.username && users.filter(u => u.role === 'super_admin' && u.is_active).length <= 1;
+        const isTheOnlyActiveSuperAdmin = user.role === 'super_admin' && user.is_active && users.filter(u => u.role === 'super_admin' && u.is_active).length <= 1;
 
         return (
           <div className="flex items-center space-x-3 opacity-0 group-hover:opacity-100 transition-opacity duration-200">
@@ -714,8 +714,13 @@ const SuperAdminDashboard: React.FC = () => {
               <button
                 onClick={(e) => { e.stopPropagation(); handleDeactivate(user.id, user.username);}}
                 className="text-yellow-600 hover:text-yellow-700 disabled:text-gray-400 dark:disabled:text-gray-500 text-xs font-medium"
-                disabled={isOnlyActiveSuperAdmin}
-                title={isOnlyActiveSuperAdmin ? "Cannot deactivate the only active super admin." : "Deactivate user"}
+                disabled={(isCurrentUser && isTheOnlyActiveSuperAdmin) || isFirstSA}
+                title={
+                  isFirstSA ? "The primary super admin account cannot be deactivated." :
+                  (isCurrentUser && isTheOnlyActiveSuperAdmin ? "Cannot deactivate your own account as the only active super admin." :
+                  (isTheOnlyActiveSuperAdmin ? "Cannot deactivate the only active super admin." : // This case might be redundant if isCurrentUser implies isTheOnlyActiveSuperAdmin for self
+                  "Deactivate user"))
+                }
               >
                 Deactivate
               </button>
@@ -747,8 +752,9 @@ const SuperAdminDashboard: React.FC = () => {
             )}
              <button
                 onClick={(e) => { e.stopPropagation(); setSelectedUserForPermissions(user); }}
-                className="text-teal-600 hover:text-teal-700 text-xs font-medium"
-                title="Edit file permissions for user"
+                className="text-teal-600 hover:text-teal-700 disabled:text-gray-400 dark:disabled:text-gray-500 disabled:cursor-not-allowed text-xs font-medium"
+                disabled={isFirstSA}
+                title={isFirstSA ? "Permissions for the primary super admin cannot be modified here." : "Manage file permissions"}
               >
                 Permissions
               </button>


### PR DESCRIPTION
Extends the protection for the primary super admin account by disabling the "Deactivate" and "Permissions" buttons for this user in the Super Admin Dashboard UI.

Changes in `frontend/src/views/SuperAdminDashboard.tsx`:
- The `disabled` conditions for the "Deactivate" and "Permissions" buttons in the user action list now also check if the user is the primary super admin (identified by `firstSuperAdminId` state).
- If the user is the primary super admin, these buttons are disabled.
- Appropriate tooltips have been added to explain why these actions are unavailable for the primary super admin, for example:
  - "The primary super admin account cannot be deactivated."
  - "Permissions for the primary super admin cannot be modified here."

This change provides an additional layer of UI protection to prevent accidental or unintended modification of the primary super admin account's status or permissions by any super admin, including themselves via this particular interface for the "Permissions" button.