### PR TITLE
I've implemented PyInstaller packaging to create a one-file executabl…

### DIFF
--- a/main.spec
+++ b/main.spec
@@ -1,0 +1,51 @@
+# main.spec
+# -*- mode: python ; coding: utf-8 -*-
+
+import sys
+sys.setrecursionlimit(5000) # Recommended for Flask apps sometimes
+
+block_cipher = None
+
+a = Analysis(['app.py'], # Main application script
+             pathex=['.'], # Add current directory to import paths
+             binaries=[],
+             datas=[
+                 ('frontend/dist', 'frontend/dist'),
+                 ('instance/default_profile_pictures', 'default_profile_pictures_bundle_location'),
+                 ('schema.sql', '.') # Bundle schema.sql at the root of the bundle
+             ],
+             hiddenimports=[
+                 'waitress',
+                 'apscheduler', # Keep this general, specific schedulers might be found
+                 'apscheduler.schedulers.background',
+                 'flask_bcrypt',
+                 'flask_jwt_extended',
+                 'flask_cors',
+                 'sqlite3',
+                 'pytz', # Added as it's used for timezone
+                 'jinja2' # Often a Flask dependency that might need to be explicit
+             ],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          a.binaries,
+          a.zipfiles,
+          a.datas,
+          [],
+          name='SoftwareDashboardApp', # Replace with the desired app name
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True, # Compresses the executable
+          upx_exclude=[],
+          runtime_tmpdir=None,
+          console=True, # True for web servers to see logs
+          onefile=True) # Create a one-file bundled executable


### PR DESCRIPTION
…e for your application.

Here's a summary of the changes:

- I modified `app.py` and `database.py` to use dynamic path resolution for the instance folder, static assets (`frontend/dist`), and `schema.sql`. This allows the application to correctly locate these resources whether you're running it as a script or as a bundled executable.
- I added logic to `app.py` to copy default files (specifically default profile pictures) from the bundled application into the `instance` folder when the executable is first run in a new environment. This ensures default assets are available.
- I created `main.spec`, a PyInstaller specification file. This file is configured to:
    - Bundle `app.py` as the main script.
    - Include necessary data files: `frontend/dist`, `instance/default_profile_pictures`, and `schema.sql`.
    - Add required hidden imports such as `waitress`, `apscheduler`, `flask_bcrypt`, `flask_jwt_extended`, `flask_cors`, `sqlite3`, `pytz`, and `jinja2`.
    - Generate a one-file, console-based executable named `SoftwareDashboardApp`.

The database initialization and backup scheduling mechanisms should work correctly with these changes, as paths are now dynamic and necessary libraries are included in the bundle.