### PR TITLE
feat: Implement superadmin announcement feature

### DIFF
--- a/frontend/src/components/notifications/NotificationBell.tsx
+++ b/frontend/src/components/notifications/NotificationBell.tsx
@@ -94,6 +94,13 @@ const NotificationBell: React.FC = () => {
   const getNotificationLink = (notification: Notification): string | undefined => {
     if (!notification.type) return undefined; // No type, no specific link
 
+    // Handle announcement notifications
+    if (notification.type === 'announcement' && notification.item_type === 'announcement') {
+      // Announcements don't link anywhere specific, clicking just marks them read.
+      // Return '#' or undefined to allow onClick to fire without navigation.
+      return '#';
+    }
+
     // Handle new content posted notifications
     if (notification.type === 'new_content_posted' || notification.type === 'content_updated') {
       if (notification.content_type && notification.item_id) {
@@ -160,6 +167,7 @@ const NotificationBell: React.FC = () => {
             case 'misc_file': basePath = '/misc'; break;
             case 'software': basePath = '/software'; break;
             case 'version': basePath = '/versions'; break;
+            // Ensure 'announcement' is not in this switch
             default: 
                 console.warn(`Unhandled item_type in fallback: ${notification.item_type}`);
                 return undefined;
@@ -216,7 +224,7 @@ const NotificationBell: React.FC = () => {
                         handleMarkAsRead(notification.id);
                       }
                       // If getNotificationLink returns '#', prevent default to avoid page jump
-                      if (!getNotificationLink(notification)) e.preventDefault(); 
+                      if (getNotificationLink(notification) === '#') e.preventDefault();
                     }}
                     className="block"
                     target="_self" // Always open in the same tab for internal navigation

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -2505,6 +2505,34 @@ export async function confirmDatabaseReset(payload: DatabaseResetConfirmPayload)
 }
 // --- End Super Admin Database Reset Functions ---
 
+// --- Announcement API ---
+export interface CreateAnnouncementResponse {
+  msg: string;
+  announcement_id: number;
+}
+
+export const createAnnouncement = async (message: string): Promise<CreateAnnouncementResponse> => {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/superadmin/announcements/create`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...getAuthHeader()
+      },
+      body: JSON.stringify({ message: message }),
+    });
+    return handleApiError(response, 'Failed to create announcement');
+  } catch (error: any) {
+    if (error instanceof TypeError && error.message.toLowerCase().includes('failed to fetch')) {
+      setGlobalOfflineStatus(true);
+      showErrorToast(OFFLINE_MESSAGE);
+    }
+    console.error('Error creating announcement:', error);
+    throw error;
+  }
+};
+// --- End Announcement API ---
+
 // --- Large File Upload (Chunked) ---
 
 function generateUUID() { // Public Domain/MIT

--- a/schema.sql
+++ b/schema.sql
@@ -371,6 +371,15 @@ CREATE TABLE IF NOT EXISTS notifications (
     updated_at TIMESTAMP DEFAULT (strftime('%Y-%m-%d %H:%M:%S', 'now', '+05:30')),
     FOREIGN KEY (user_id) REFERENCES users (id)
 );
+
+CREATE TABLE announcements (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    message TEXT NOT NULL,
+    created_by_user_id INTEGER,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (created_by_user_id) REFERENCES users(id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_notifications_user_id ON notifications (user_id);
 CREATE INDEX IF NOT EXISTS idx_notifications_item_id_item_type ON notifications (item_id, item_type);
 CREATE TRIGGER IF NOT EXISTS update_notifications_updated_at


### PR DESCRIPTION
This commit introduces a feature allowing superadmins to send announcements to all users.

Key changes:

Backend:
- Added `announcements` table to the database schema (`schema.sql`).
- Created a new API endpoint POST `/api/superadmin/announcements/create`.
  - This endpoint allows superadmins to create an announcement message.
  - Upon creation, it generates notifications for all active users.
  - The action is logged in the audit logs.

Frontend:
- Added a "Send Announcement" section to the SuperAdmin Dashboard (`SuperAdminDashboard.tsx`).
  - Includes a textarea for the message and a send button.
  - Provides loading and feedback states.
- Implemented `createAnnouncement` function in `api.ts` to call the new backend endpoint.
- Updated `NotificationBell.tsx` to correctly handle the display and click behavior for notifications of type 'announcement', ensuring they are marked as read without attempting to navigate.

Users will now receive announcements as part of their standard notifications.