### PR TITLE
Fix: Resolve METHOD_NOT_ALLOWED error for new chats

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -596,6 +596,43 @@ export async function sendMessage(
     throw error;
   }
 }
+
+// Add the new function here:
+export async function startConversationAndSendMessage(
+  recipientUserId: number,
+  content: string,
+  fileUrl?: string,
+  fileName?: string,
+  fileType?: string
+): Promise<ChatConversation> { // Assuming backend returns the full conversation object
+  try {
+    const payload: any = {
+      recipient_id: recipientUserId,
+      content: content
+    };
+    if (fileUrl && fileName && fileType) {
+      payload.file_url = fileUrl;
+      payload.file_name = fileName;
+      payload.file_type = fileType;
+    }
+
+    const response = await fetch(`${API_BASE_URL}/api/chat/conversations/start_and_send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
+      body: JSON.stringify(payload),
+    });
+    // Assuming handleApiError will parse the JSON response and return it as ChatConversation
+    // The backend should return the full conversation object, potentially including the first message as 'last_message'
+    return handleApiError(response, 'Failed to start conversation and send message');
+  } catch (error: any) {
+    if (error instanceof TypeError && error.message.toLowerCase().includes('failed to fetch')) {
+      setGlobalOfflineStatus(true);
+      showErrorToast(OFFLINE_MESSAGE);
+    }
+    console.error(`Error starting conversation with user ${recipientUserId}:`, error);
+    throw error;
+  }
+}
 // --- End Chat API Functions ---
 
 // --- Super Admin File Permission Management Functions ---


### PR DESCRIPTION
This commit addresses an issue where sending the first message in a new chat would result in a 405 (METHOD NOT ALLOWED) error. This was due to the frontend attempting to use an undefined conversation_id.

Changes:
- Modified `ChatMain.tsx` to create a provisional conversation object locally when a new chat is initiated, rather than immediately calling an API to create the conversation.
- Added a new backend endpoint `/api/chat/conversations/start_and_send` in `app.py`. This endpoint is responsible for creating the conversation record in the database and sending the first message in a single atomic operation.
- Updated `ChatWindow.tsx` to use this new endpoint for sending the first message in a provisional chat. Subsequent messages in an established chat use the existing endpoint.
- Adjusted the `/api/chat/upload_file` backend route to correctly handle file uploads for provisional chats, where a recipient_id might be passed instead of a full conversation_id for path creation.
- The `api.ts` service was updated with a new function `startConversationAndSendMessage` to call the new backend endpoint.

This approach ensures that a valid conversation_id is always available when messages are sent and that the conversation is formally created only when the first message is exchanged.