### PR TITLE
Feat: Implement expandable descriptions in table views

### DIFF
--- a/frontend/src/components/shared/ExpandableText.tsx
+++ b/frontend/src/components/shared/ExpandableText.tsx
@@ -1,0 +1,53 @@
+// frontend/src/components/shared/ExpandableText.tsx
+import React, { useState, useMemo } from 'react';
+
+interface ExpandableTextProps {
+  text: string | null | undefined;
+  charLimit?: number;
+  className?: string; // Allow passing additional class names for the container
+}
+
+const DEFAULT_CHAR_LIMIT = 100; // Default character limit for truncation
+
+const ExpandableText: React.FC<ExpandableTextProps> = ({
+  text,
+  charLimit = DEFAULT_CHAR_LIMIT,
+  className = 'text-sm text-gray-600 dark:text-gray-300 block max-w-xs', // Default styling from views
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const fullText = text || '-'; // Display '-' if text is null or undefined
+
+  const isTruncatable = useMemo(() => fullText.length > charLimit, [fullText, charLimit]);
+
+  const displayText = useMemo(() => {
+    if (!isTruncatable || isExpanded) {
+      return fullText;
+    }
+    return `${fullText.substring(0, charLimit)}...`;
+  }, [fullText, charLimit, isExpanded, isTruncatable]);
+
+  const toggleReadMore = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    e.stopPropagation(); // Prevent row click or other parent events
+    setIsExpanded(!isExpanded);
+  };
+
+  return (
+    <div className={className}>
+      <span style={{ whiteSpace: isExpanded ? 'normal' : 'nowrap', overflow: isExpanded ? 'visible' : 'hidden', textOverflow: isExpanded ? 'clip' : 'ellipsis' }}>
+        {displayText}
+      </span>
+      {isTruncatable && (
+        <button
+          onClick={toggleReadMore}
+          className="ml-1 text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 text-xs font-medium focus:outline-none"
+          aria-expanded={isExpanded}
+        >
+          {isExpanded ? 'Read Less' : 'Read More'}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default ExpandableText;

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -27,6 +27,7 @@ import ConfirmationModal from '../components/shared/ConfirmationModal';
 import Modal from '../components/shared/Modal';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils';
 import CommentSection from '../components/comments/CommentSection';
+import ExpandableText from '../components/shared/ExpandableText';
 
 interface OutletContextType {
   searchTerm: string;
@@ -429,7 +430,17 @@ useEffect(() => {
   const columns: ColumnDef<DocumentType>[] = [
     { key: 'doc_name', header: 'Name', sortable: true }, { key: 'doc_type', header: 'Type', sortable: true },
     { key: 'software_name', header: 'Software', sortable: true },
-    { key: 'description', header: 'Description', render: (d: DocumentType) => <span className="text-sm text-gray-600 block max-w-xs truncate" title={d.description||''}>{d.description||'-'}</span> },
+    {
+      key: 'description',
+      header: 'Description',
+      render: (d: DocumentType) => (
+        <ExpandableText
+          text={d.description}
+          charLimit={100} // You can adjust this character limit
+          // The default className in ExpandableText already includes max-w-xs and text styling
+        />
+      )
+    },
     { 
       key: 'download_link', 
       header: 'Download', 

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -19,6 +19,7 @@ import ConfirmationModal from '../components/shared/ConfirmationModal';
 import Modal from '../components/shared/Modal';
 import { PlusCircle, Edit3, Trash2, Star, Filter, ChevronUp, Link as LinkIconLucide, Download, Move, AlertTriangle, MessageSquare } from 'lucide-react'; // Added MessageSquare
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils';
+import ExpandableText from '../components/shared/ExpandableText';
 
 interface OutletContextType {
   searchTerm: string;
@@ -327,7 +328,16 @@ const LinksView: React.FC = () => {
         return <div className="text-center">{content}</div>;
       }
     },
-    { key: 'description', header: 'Description', render: l => <span className="text-sm text-gray-600 block max-w-xs truncate" title={l.description || ''}>{l.description || '-'}</span> },
+    {
+      key: 'description',
+      header: 'Description',
+      render: (l: LinkType) => (
+        <ExpandableText
+          text={l.description}
+          charLimit={100} // Consistent character limit
+        />
+      )
+    },
     {
       key: 'url',
       header: 'Link',

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -29,6 +29,7 @@ import Fuse from 'fuse.js';
 import ConfirmationModal from '../components/shared/ConfirmationModal';
 import Modal from '../components/shared/Modal';
 import { showErrorToast, showSuccessToast } from '../utils/toastUtils';
+import ExpandableText from '../components/shared/ExpandableText';
 
 interface OutletContextType {
   searchTerm: string;
@@ -407,7 +408,16 @@ const PatchesView: React.FC = () => {
         return <div className="text-center">{content}</div>;
       }
     },
-    { key: 'description', header: 'Description', render: p => <span className="text-sm text-gray-600 block max-w-xs truncate" title={p.description || ''}>{p.description || '-'}</span> },
+    {
+      key: 'description',
+      header: 'Description',
+      render: (p: PatchType) => (
+        <ExpandableText
+          text={p.description}
+          charLimit={100} // Consistent character limit
+        />
+      )
+    },
     { key: 'release_date', header: 'Release Date', sortable: true, render: (item: PatchType) => formatDateDisplay(item.release_date) }, // Stays the same
     {
       key: 'download_link',


### PR DESCRIPTION
Previously, long descriptions in the Documents, Patches, and Links tables were truncated with an ellipsis, and the full text was only visible on hover via the title attribute. This made it difficult for you to read longer descriptions.

This commit introduces an "ExpandableText" component that:
- Displays a truncated version of the text initially (e.g., ~100 chars).
- Shows a "Read More" link if the text exceeds the limit.
- Allows you to click "Read More" to expand the text in place.
- Changes the link to "Read Less" when expanded, allowing you to collapse the text again.

This component has been integrated into the description columns of the DataTables in `DocumentsView.tsx`, `PatchesView.tsx`, and `LinksView.tsx`, improving the readability and your experience for items with long descriptions.