### PR TITLE
feat: Extend user-friendly UNIQUE constraint error handling

### DIFF
--- a/frontend/src/components/admin/AdminDocumentEntryForm.tsx
+++ b/frontend/src/components/admin/AdminDocumentEntryForm.tsx
@@ -273,9 +273,21 @@ const role = user?.role; // Access role safely, as user can be null
       }
     } catch (err: any) {
       console.error("Error in AdminDocumentEntryForm onSubmit:", err);
-      const message = err.response?.data?.msg || err.message || `Failed to ${isEditMode && data.inputMode === 'url' ? 'update' : 'add'} document.`;
-      showErrorToast(message);
-      if (data.inputMode === 'upload') setIsUploading(false); // Also set isUploading to false on error
+      const backendMessage = err.response?.data?.msg || err.message;
+      let userMessage = `Failed to ${isEditMode && data.inputMode === 'url' ? 'update' : 'add'} document.`;
+
+      if (backendMessage && typeof backendMessage === 'string' && backendMessage.includes("UNIQUE constraint failed")) {
+        if (isEditMode) {
+          userMessage = "A document with this name already exists for this software. Please use a different name or check for duplicates.";
+        } else {
+          userMessage = "A document with this name already exists for this software. Please use a different name.";
+        }
+      } else if (backendMessage) {
+        userMessage = backendMessage;
+      }
+      // Future: Add checks for other constraint errors here if needed (e.g., NOT NULL, FOREIGN KEY)
+      showErrorToast(userMessage);
+      if (data.inputMode === 'upload') setIsUploading(false);
     } finally {
       console.log("AdminDocumentEntryForm onSubmit finally block reached.");
       setIsLoading(false);

--- a/frontend/src/components/admin/AdminLinkEntryForm.tsx
+++ b/frontend/src/components/admin/AdminLinkEntryForm.tsx
@@ -375,9 +375,21 @@ const AdminLinkEntryForm: React.FC<AdminLinkEntryFormProps> = ({
         setValue('typedVersionString', '');
       }
     } catch (err: any) {
-      const message = err.response?.data?.msg || err.message || `Failed to ${isEditMode && data.inputMode === 'url' ? 'update' : 'add'} link.`;
-      showErrorToast(message); // Standardized
-      if (data.inputMode === 'upload') setIsUploading(false); // Also set isUploading to false on error
+      const backendMessage = err.response?.data?.msg || err.message;
+      let userMessage = `Failed to ${isEditMode ? 'update' : 'add'} link.`;
+
+      if (backendMessage && typeof backendMessage === 'string' && backendMessage.includes("UNIQUE constraint failed")) {
+        if (isEditMode) {
+          userMessage = "A link with this title already exists for this software/version. Please use a different title or check for duplicates.";
+        } else {
+          userMessage = "A link with this title already exists for this software/version. Please use a different title.";
+        }
+      } else if (backendMessage) {
+        userMessage = backendMessage;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here
+      if (data.inputMode === 'upload') setIsUploading(false);
     }
     finally {
       setIsLoading(false);

--- a/frontend/src/components/admin/AdminMiscCategoryForm.tsx
+++ b/frontend/src/components/admin/AdminMiscCategoryForm.tsx
@@ -105,9 +105,16 @@ const role = user?.role; // Access role safely, as user can be null
       if (onSuccess) onSuccess(resultCategory); 
 
     } catch (err: any) {
-      const apiErrorMessage = err.response?.data?.msg || err.message;
-      // showErrorToast(apiErrorMessage || `Failed to ${isEditMode ? 'update' : 'add'} category.`);
-      showErrorToast(apiErrorMessage || 'Failed to save category.');
+      const backendMessage = err.response?.data?.msg || err.message;
+      let userMessage = `Failed to ${isEditMode ? 'update' : 'add'} category.`;
+
+      if (backendMessage && typeof backendMessage === 'string' && backendMessage.includes("UNIQUE constraint failed")) {
+        userMessage = "A category with this name already exists. Please use a different name.";
+      } else if (backendMessage) {
+        userMessage = backendMessage;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/admin/AdminPatchEntryForm.tsx
+++ b/frontend/src/components/admin/AdminPatchEntryForm.tsx
@@ -408,9 +408,21 @@ const AdminPatchEntryForm: React.FC<AdminPatchEntryFormProps> = ({
         setValue('typedVersionString', '');
       }
     } catch (err: any) {
-      const message = err.response?.data?.msg || err.message || `Failed to ${isEditMode && data.inputMode === 'url' ? 'update' : 'add'} patch.`;
-      showErrorToast(message); // Standardized
-      if (data.inputMode === 'upload') setIsUploading(false); // Also set isUploading to false on error
+      const backendMessage = err.response?.data?.msg || err.message;
+      let userMessage = `Failed to ${isEditMode ? 'update' : 'add'} patch.`;
+
+      if (backendMessage && typeof backendMessage === 'string' && backendMessage.includes("UNIQUE constraint failed")) {
+        if (isEditMode) {
+          userMessage = "A patch with this name already exists for this software/version. Please use a different name or check for duplicates.";
+        } else {
+          userMessage = "A patch with this name already exists for this software/version. Please use a different name.";
+        }
+      } else if (backendMessage) {
+        userMessage = backendMessage;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here
+      if (data.inputMode === 'upload') setIsUploading(false);
     } finally {
       setIsLoading(false);
       if (data.inputMode === 'upload') setIsUploading(false); // Ensure isUploading is reset

--- a/frontend/src/components/admin/AdminUploadToMiscForm.tsx
+++ b/frontend/src/components/admin/AdminUploadToMiscForm.tsx
@@ -202,9 +202,17 @@ const role = user?.role; // Access role safely, as user can be null
         return;
       }
     } catch (err: any) {
-      const message = err.response?.data?.msg || err.message || `File operation failed.`;
-      showErrorToast(message); // Standardized
-      if (data.selectedFile) setIsUploading(false); // Also set isUploading to false on error
+      const backendMessage = err.response?.data?.msg || err.message;
+      let userMessage = "File operation failed.";
+
+      if (backendMessage && typeof backendMessage === 'string' && backendMessage.includes("UNIQUE constraint failed")) {
+        userMessage = "A file with this title or name already exists in this category. Please use a different title or check for duplicates.";
+      } else if (backendMessage) {
+        userMessage = backendMessage;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here
+      if (data.selectedFile) setIsUploading(false);
     } finally {
       setIsLoading(false);
       if (data.selectedFile) setIsUploading(false); // Ensure isUploading is reset

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -422,7 +422,16 @@ useEffect(() => {
       const res = await bulkMoveItems(Array.from(selectedDocumentIds), 'document' as BulkItemType, { target_software_id: targetSoftwareForMove });
       showSuccessToast(res.msg || `${res.moved_count} item(s) moved.`);
       setSelectedDocumentIds(new Set()); fetchAndSetDocuments(1, true);
-    } catch (e: any) { showErrorToast(e.message || "Bulk move failed."); }
+    } catch (e: any) {
+      let userMessage = "Bulk move failed.";
+      if (e.message && typeof e.message === 'string' && e.message.includes("UNIQUE constraint failed")) {
+        userMessage = "A document with this name already exists in the target software category. Please check for duplicates.";
+      } else if (e.message) {
+        userMessage = e.message;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here if needed
+    }
     finally { setIsMovingSelected(false); setTargetSoftwareForMove(null); }
   };
 

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -294,7 +294,16 @@ const LinksView: React.FC = () => {
       const res = await bulkMoveItems(Array.from(selectedLinkIds), 'link', targetMetadata);
       showSuccessToast(res.msg || `${res.moved_count} link(s) moved.`);
       setSelectedLinkIds(new Set()); fetchAndSetLinks(1, true);
-    } catch (e: any) { showErrorToast(e.message || "Bulk move failed."); }
+    } catch (e: any) {
+      let userMessage = "Bulk move failed.";
+      if (e.message && typeof e.message === 'string' && e.message.includes("UNIQUE constraint failed")) {
+        userMessage = "A link with this title already exists for the target software/version. Please check for duplicates.";
+      } else if (e.message) {
+        userMessage = e.message;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here
+    }
     finally { setIsMovingSelected(false); setModalSelectedSoftwareId(null); setModalSelectedVersionId(undefined); }
   };
 

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -256,7 +256,16 @@ const role = user?.role; // Access role safely, as user can be null
       const res = await bulkMoveItems(Array.from(selectedMiscFileIds), 'misc_file', { target_misc_category_id: modalSelectedCategoryId });
       showSuccessToast(res.msg || `${res.moved_count} file(s) moved.`);
       setSelectedMiscFileIds(new Set()); fetchAndSetMiscFiles(1, true);
-    } catch (e: any) { showErrorToast(e.message || "Bulk move failed."); }
+    } catch (e: any) {
+      let userMessage = "Bulk move failed.";
+      if (e.message && typeof e.message === 'string' && e.message.includes("UNIQUE constraint failed")) {
+        userMessage = "A file with this name already exists in the target category. Please check for duplicates.";
+      } else if (e.message) {
+        userMessage = e.message;
+      }
+      showErrorToast(userMessage);
+      // Future: Add checks for other constraint errors here
+    }
     finally { setIsMovingSelected(false); setModalSelectedCategoryId(null); }
   };
 

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -361,9 +361,11 @@ const PatchesView: React.FC = () => {
         if (e.response.data.msg) {
           // console.warn('[PatchesView] Backend message for conflict:', e.response.data.msg); // Removed
         }
-      } else if (e.message) {
-        showErrorToast(e.message);
-      } else {
+      } else if (e.message && typeof e.message === 'string' && e.message.includes("UNIQUE constraint failed")) {
+        showErrorToast("A patch with this name already exists for the target software/version. Please check for duplicates.");
+     } else if (e.message) {
+       showErrorToast(e.message);
+     } else {
         showErrorToast("Bulk move failed due to an unexpected error.");
       }
       // It's good practice to also log the full error for debugging purposes


### PR DESCRIPTION
This commit extends the user-friendly error message handling for 'UNIQUE constraint failed' errors to the Miscellaneous, Patches, and Links sections of the application.

Previously, this enhanced error handling was implemented only for the Documents section.

Changes were made in the following files:

- `frontend/src/views/MiscView.tsx`:
  - Updated `handleConfirmBulkMoveMiscFiles` for bulk move errors.
- `frontend/src/views/PatchesView.tsx`:
  - Updated `handleConfirmBulkMovePatches` for bulk move errors.
- `frontend/src/views/LinksView.tsx`:
  - Updated `handleConfirmBulkMoveLinks` for bulk move errors.
- `frontend/src/components/admin/AdminLinkEntryForm.tsx`:
  - Updated `onSubmit` for add/edit link title errors.
- `frontend/src/components/admin/AdminPatchEntryForm.tsx`:
  - Updated `onSubmit` for add/edit patch name errors.
- `frontend/src/components/admin/AdminMiscCategoryForm.tsx`:
  - Updated `onSubmit` for add/edit category name errors.
- `frontend/src/components/admin/AdminUploadToMiscForm.tsx`:
  - Updated `onSubmit` for misc file title/name errors during upload/edit.

This ensures a consistent and improved user experience by providing clearer, context-specific feedback for UNIQUE constraint violations across more areas of the application, rather than exposing raw database errors.