### PR TITLE
Fix: Improve file upload robustness and cleanup

### DIFF
--- a/frontend/src/components/admin/AdminDocumentEntryForm.tsx
+++ b/frontend/src/components/admin/AdminDocumentEntryForm.tsx
@@ -4,7 +4,7 @@ import { useForm, SubmitHandler, FieldErrors } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
 // import { toast } from 'react-toastify'; // Replaced with utils
-import { showSuccessToast, showErrorToast } from '../../utils/toastUtils'; // Added utils
+import { showSuccessToast, showErrorToast, showWarningToast } from '../../utils/toastUtils'; // Added utils
 import { Software, Document as DocumentType, AddDocumentPayload, EditDocumentPayload } from '../../types'; // Added EditDocumentPayload
 import {
   fetchSoftware,
@@ -117,6 +117,21 @@ const role = user?.role; // Access role safely, as user can be null
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [isUploading]);
+
+  // Effect to warn user if they change tabs during upload
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' && isUploading) {
+        showWarningToast('Changing tabs or minimizing the window might interrupt the upload process.');
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isUploading]); // Dependency array includes isUploading
 
   useEffect(() => {
     if (isAuthenticated && (role === 'admin' || role === 'super_admin')) {

--- a/frontend/src/components/admin/AdminLinkEntryForm.tsx
+++ b/frontend/src/components/admin/AdminLinkEntryForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useForm, Controller, SubmitHandler, FieldErrors } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { showSuccessToast, showErrorToast } from '../../utils/toastUtils'; // Standardized toast
+import { showSuccessToast, showErrorToast, showWarningToast } from '../../utils/toastUtils'; // Standardized toast
 import {
   Software,
   Link as LinkType,
@@ -156,6 +156,21 @@ const AdminLinkEntryForm: React.FC<AdminLinkEntryFormProps> = ({
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [isUploading]);
+
+  // Effect to warn user if they change tabs during upload
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' && isUploading) {
+        showWarningToast('Changing tabs or minimizing the window might interrupt the upload process.');
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isUploading]); // Dependency array includes isUploading
 
   useEffect(() => {
     if (isAuthenticated && (role === 'admin' || role === 'super_admin')) {

--- a/frontend/src/components/admin/AdminPatchEntryForm.tsx
+++ b/frontend/src/components/admin/AdminPatchEntryForm.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useForm, Controller, SubmitHandler, FieldErrors } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { showSuccessToast, showErrorToast } from '../../utils/toastUtils'; // Standardized toast
+import { showSuccessToast, showErrorToast, showWarningToast } from '../../utils/toastUtils'; // Standardized toast
 import {
   Software,
   Patch as PatchType,
@@ -154,6 +154,21 @@ const AdminPatchEntryForm: React.FC<AdminPatchEntryFormProps> = ({
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [isUploading]);
+
+  // Effect to warn user if they change tabs during upload
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' && isUploading) {
+        showWarningToast('Changing tabs or minimizing the window might interrupt the upload process.');
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isUploading]); // Dependency array includes isUploading
 
   // Fetch software list for the product dropdown
   useEffect(() => {

--- a/frontend/src/components/admin/AdminUploadToMiscForm.tsx
+++ b/frontend/src/components/admin/AdminUploadToMiscForm.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useForm, SubmitHandler, FieldErrors } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import {showErrorToast } from '../../utils/toastUtils'; // Standardized toast
+import {showErrorToast, showWarningToast } from '../../utils/toastUtils'; // Standardized toast
 import { useAuth } from '../../context/AuthContext';
 import {
   // uploadAdminMiscFile, // To be replaced by chunked upload
@@ -94,6 +94,21 @@ const role = user?.role; // Access role safely, as user can be null
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [isUploading]);
+
+  // Effect to warn user if they change tabs during upload
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden' && isUploading) {
+        showWarningToast('Changing tabs or minimizing the window might interrupt the upload process.');
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isUploading]); // Dependency array includes isUploading
 
   // Fetch categories for the dropdown
   useEffect(() => {

--- a/scheduler.py
+++ b/scheduler.py
@@ -3,9 +3,11 @@ import sqlite3
 import os
 from datetime import datetime, timedelta
 from flask import current_app # To access app.config for DB path and retention period
+import logging # For logging within scheduler tasks
 
 # Initialize scheduler
 scheduler = APScheduler()
+logger = logging.getLogger(__name__) # Standard Python logger for scheduler
 
 def init_scheduler(app):
     """Initialize and start the scheduler."""
@@ -16,49 +18,104 @@ def init_scheduler(app):
     # Ensure delete_old_messages_task is defined or imported before this line
     if not scheduler.get_job('Delete Old Messages'):
         scheduler.add_job(id='Delete Old Messages', func=delete_old_messages_task, trigger='interval', days=1)
-        print("Scheduled 'Delete Old Messages' job to run daily.")
+        logger.info("Scheduled 'Delete Old Messages' job to run daily.")
     else:
-        print("'Delete Old Messages' job already scheduled.")
+        logger.info("'Delete Old Messages' job already scheduled.")
+
+    if not scheduler.get_job('Cleanup Old Temporary Files'):
+        # Schedule to run daily at 3 AM
+        scheduler.add_job(id='Cleanup Old Temporary Files', func=cleanup_old_temporary_files_task, trigger='cron', hour=3, minute=0)
+        logger.info("Scheduled 'Cleanup Old Temporary Files' job to run daily at 3:00 AM.")
+    else:
+        logger.info("'Cleanup Old Temporary Files' job already scheduled.")
+
+def cleanup_old_temporary_files_task():
+    logger.info("Running cleanup_old_temporary_files_task...")
+    try:
+        instance_path = current_app.config.get('INSTANCE_FOLDER_PATH')
+        if not instance_path or not os.path.isdir(instance_path):
+            logger.error(f"INSTANCE_FOLDER_PATH '{instance_path}' is not defined or not a directory. Skipping cleanup.")
+            return
+
+        # 1. Cleanup tmp_standard_uploads
+        tmp_standard_uploads_dir = os.path.join(instance_path, 'tmp_standard_uploads')
+        if os.path.exists(tmp_standard_uploads_dir):
+            logger.info(f"Scanning {tmp_standard_uploads_dir} for old files...")
+            cutoff_time = datetime.now() - timedelta(hours=24)
+            deleted_standard_count = 0
+            for filename in os.listdir(tmp_standard_uploads_dir):
+                file_path = os.path.join(tmp_standard_uploads_dir, filename)
+                try:
+                    if os.path.isfile(file_path):
+                        file_mod_time = datetime.fromtimestamp(os.path.getmtime(file_path))
+                        if file_mod_time < cutoff_time:
+                            os.remove(file_path)
+                            logger.info(f"Deleted old temporary file: {file_path}")
+                            deleted_standard_count += 1
+                except Exception as e_std:
+                    logger.error(f"Error processing file {file_path} in tmp_standard_uploads: {e_std}")
+            logger.info(f"Cleanup of tmp_standard_uploads complete. Deleted {deleted_standard_count} files.")
+        else:
+            logger.info(f"Directory {tmp_standard_uploads_dir} does not exist. Skipping cleanup for it.")
+
+        # 2. Cleanup TMP_LARGE_UPLOADS_FOLDER (for .part files)
+        tmp_large_uploads_dir = current_app.config.get('TMP_LARGE_UPLOADS_FOLDER') # This is already an absolute path
+        if tmp_large_uploads_dir and os.path.exists(tmp_large_uploads_dir):
+            logger.info(f"Scanning {tmp_large_uploads_dir} for old .part files...")
+            cutoff_time_large = datetime.now() - timedelta(hours=24) # Can use the same or different cutoff
+            deleted_large_count = 0
+            for filename in os.listdir(tmp_large_uploads_dir):
+                if filename.endswith('.part'):
+                    file_path = os.path.join(tmp_large_uploads_dir, filename)
+                    try:
+                        if os.path.isfile(file_path):
+                            file_mod_time = datetime.fromtimestamp(os.path.getmtime(file_path))
+                            if file_mod_time < cutoff_time_large:
+                                os.remove(file_path)
+                                logger.info(f"Deleted old temporary large file part: {file_path}")
+                                deleted_large_count +=1
+                    except Exception as e_large:
+                        logger.error(f"Error processing file {file_path} in TMP_LARGE_UPLOADS_FOLDER: {e_large}")
+            logger.info(f"Cleanup of TMP_LARGE_UPLOADS_FOLDER complete. Deleted {deleted_large_count} .part files.")
+        else:
+            logger.info(f"Directory {tmp_large_uploads_dir} does not exist or not configured. Skipping cleanup for it.")
+
+    except Exception as e:
+        logger.error(f"An unexpected error occurred in cleanup_old_temporary_files_task: {e}", exc_info=True)
+    finally:
+        logger.info("cleanup_old_temporary_files_task finished.")
+
 
 def delete_old_messages_task():
-    print("Running delete_old_messages_task...")
+    logger.info("Running delete_old_messages_task...") # Changed print to logger.info
     try:
-        # Construct the full path to the database file
-        # Assuming the 'instance' folder is at the same level as the script running Flask (app.py)
-        # and app.config['DATABASE_PATH'] stores 'instance/software_dashboard.db'
         db_path = current_app.config['DATABASE_PATH']
         
-        # Ensure the path is absolute if it's not already
         if not os.path.isabs(db_path):
-            # Assuming app.py is in the root, and instance folder is relative to it
-            # This might need adjustment based on your project structure if current_app.root_path is different
             db_path = os.path.join(current_app.root_path, db_path)
 
-        print(f"Connecting to database at: {db_path}")
+        logger.info(f"Connecting to database at: {db_path}") # Changed print to logger.info
         conn = sqlite3.connect(db_path)
         cursor = conn.cursor()
 
-        # Get retention period from app config, default to 180 days if not set
         retention_days = current_app.config.get('MESSAGE_RETENTION_DAYS', 180)
-        print(f"Using message retention period of {retention_days} days.")
+        logger.info(f"Using message retention period of {retention_days} days.") # Changed print to logger.info
         cutoff_date = datetime.now() - timedelta(days=int(retention_days))
         cutoff_timestamp = cutoff_date.strftime('%Y-%m-%d %H:%M:%S')
 
-        print(f"Deleting messages older than: {cutoff_timestamp}")
+        logger.info(f"Deleting messages older than: {cutoff_timestamp}") # Changed print to logger.info
         
-        # Delete old messages
-        # The 'created_at' column in 'messages' table is expected to be in 'YYYY-MM-DD HH:MM:SS' format
         cursor.execute("DELETE FROM messages WHERE created_at < ?", (cutoff_timestamp,))
         conn.commit()
         
         deleted_count = cursor.rowcount
-        print(f"Successfully deleted {deleted_count} old messages.")
+        logger.info(f"Successfully deleted {deleted_count} old messages.") # Changed print to logger.info
 
     except sqlite3.Error as e:
-        print(f"Database error in delete_old_messages_task: {e}")
+        logger.error(f"Database error in delete_old_messages_task: {e}") # Changed print to logger.error
     except Exception as e:
-        print(f"An unexpected error occurred in delete_old_messages_task: {e}")
+        logger.error(f"An unexpected error occurred in delete_old_messages_task: {e}", exc_info=True) # Changed print to logger.error
     finally:
         if 'conn' in locals() and conn:
             conn.close()
-        print("delete_old_messages_task finished.")
+        logger.info("delete_old_messages_task finished.") # Changed print to logger.info


### PR DESCRIPTION
This commit introduces several improvements to the file upload process:

Frontend:
- Added a warning toast notification if you switch browser tabs while a file upload is in progress. This applies to documents, patches, links, and miscellaneous file uploads.

Backend:
- Standard file uploads now use a temporary directory. Files are saved to their final destination only after a successful database commit. This prevents partial files in the final destination due to upload or DB errors.
- Implemented a daily scheduled task to clean up:
    - Old files from the temporary directory for standard uploads.
    - Old orphaned `.part` files from incomplete large file uploads.

These changes enhance your experience by warning about potential upload interruptions and improve system stability by ensuring better cleanup of temporary and orphaned files, preventing them from filling up storage.