### PR TITLE
Fix: Restrict VMS compatibility option to VA software type

### DIFF
--- a/frontend/src/components/admin/AdminLinkEntryForm.tsx
+++ b/frontend/src/components/admin/AdminLinkEntryForm.tsx
@@ -190,7 +190,7 @@ const AdminLinkEntryForm: React.FC<AdminLinkEntryFormProps> = ({
       setValue('typedVersionString', '');
 
       const selectedSoftware = softwareList.find(sw => sw.id.toString() === watchedSoftwareId);
-      if (selectedSoftware && (selectedSoftware.name === 'VMS' || selectedSoftware.name === 'VA')) {
+      if (selectedSoftware && selectedSoftware.name === 'VA') {
         setIsVmsOrVaSoftware(true);
         const vmsSoftware = softwareList.find(sw => sw.name === 'VMS');
         if (vmsSoftware) {

--- a/frontend/src/components/admin/AdminPatchEntryForm.tsx
+++ b/frontend/src/components/admin/AdminPatchEntryForm.tsx
@@ -190,7 +190,7 @@ const AdminPatchEntryForm: React.FC<AdminPatchEntryFormProps> = ({
       setValue('typedVersionString', '');
 
       const selectedSoftware = softwareList.find(sw => sw.id.toString() === watchedSoftwareId);
-      if (selectedSoftware && (selectedSoftware.name === 'VMS' || selectedSoftware.name === 'VA')) {
+      if (selectedSoftware && selectedSoftware.name === 'VA') {
         setIsVmsOrVaSoftware(true);
         // Fetch VMS versions specifically for the multi-select
         const vmsSoftware = softwareList.find(sw => sw.name === 'VMS');


### PR DESCRIPTION
The VMS compatibility option in the Link and Patch entry forms was incorrectly displayed when you selected the software type 'VMS'.

I've updated the conditional logic in:
- frontend/src/components/admin/AdminLinkEntryForm.tsx
- frontend/src/components/admin/AdminPatchEntryForm.tsx

The VMS compatibility section will now only appear when you select the software type 'VA', as per your requirement.
I reviewed AdminDocumentEntryForm.tsx and it did not contain this functionality, so I made no changes to it.