### PR TITLE
Potential fix for code scanning alert no. 101: Clear-text logging of sensitive information

### DIFF
--- a/app.py
+++ b/app.py
@@ -2111,11 +2111,8 @@ def login():
         if 'password_reset_required' in user.keys():
             raw_password_reset_flag = user['password_reset_required']
             raw_password_reset_flag_type = type(user['password_reset_required']).__name__
-        app.logger.debug(f"[Login Debug] Raw user['password_reset_required']: {raw_password_reset_flag}")
-        app.logger.debug(f"[Login Debug] Type of user['password_reset_required']: {raw_password_reset_flag_type}")
         password_reset_required = user['password_reset_required'] if 'password_reset_required' in user.keys() and user['password_reset_required'] is not None else False
-        app.logger.debug(f"[Login Debug] Calculated password_reset_required for JSON response: {password_reset_required}")
-        app.logger.debug(f"[Login Debug] Type of calculated password_reset_required for JSON response: {type(password_reset_required).__name__}")
+        app.logger.debug("[Login Debug] Processed password_reset_required flag for JSON response.")
 
         profile_picture_url = None
         if user['profile_picture_filename']:


### PR DESCRIPTION
Potential fix for [https://github.com/sahyam2023/dashboard/security/code-scanning/101](https://github.com/sahyam2023/dashboard/security/code-scanning/101)

To fix the issue, we will remove or sanitize the logging of `password_reset_required` and its type. Since this field is flagged as potentially sensitive, it should not be logged in clear text. Instead, we can log a generic message indicating that the field was processed without including its value. This approach ensures that no sensitive data is exposed while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
