### PR TITLE
Implement user-configurable column visibility preferences

### DIFF
--- a/app.py
+++ b/app.py
@@ -11723,6 +11723,65 @@ def user_submit_feedback():
         app.logger.error(f"Error submitting user feedback: {e}", exc_info=True)
         return jsonify(msg="An unexpected server error occurred while submitting feedback."), 500
 
+@app.route('/api/user/profile/column-prefs', methods=['GET'])
+@active_user_required
+def get_user_column_prefs():
+    user_id = int(get_jwt_identity())
+    db = get_db()
+    user_prefs_row = db.execute("SELECT column_visibility_prefs FROM users WHERE id = ?", (user_id,)).fetchone()
+
+    if user_prefs_row and user_prefs_row['column_visibility_prefs']:
+        try:
+            prefs = json.loads(user_prefs_row['column_visibility_prefs'])
+            return jsonify(prefs), 200
+        except json.JSONDecodeError:
+            app.logger.error(f"Failed to parse column_visibility_prefs for user {user_id}. Data: {user_prefs_row['column_visibility_prefs']}")
+            return jsonify({}), 200 # Return empty dict if parsing fails or no prefs
+    else:
+        return jsonify({}), 200 # No preferences set, return empty dict
+
+@app.route('/api/user/profile/column-prefs', methods=['PUT'])
+@active_user_required
+def update_user_column_prefs():
+    user_id = int(get_jwt_identity())
+    new_prefs_payload = request.get_json()
+
+    if new_prefs_payload is None or not isinstance(new_prefs_payload, dict):
+        return jsonify(msg="Invalid or missing JSON data in request body. Expected an object."), 400
+
+    # Basic validation of the payload structure (can be enhanced)
+    allowed_tables = ["documents", "patches", "links"]
+    for table_key, column_prefs in new_prefs_payload.items():
+        if table_key not in allowed_tables:
+            return jsonify(msg=f"Invalid table key '{table_key}' in preferences."), 400
+        if not isinstance(column_prefs, dict):
+            return jsonify(msg=f"Column preferences for '{table_key}' must be an object."), 400
+        for column_name, is_visible in column_prefs.items():
+            if not isinstance(column_name, str) or not isinstance(is_visible, bool):
+                return jsonify(msg=f"Invalid preference for '{table_key}': column '{column_name}' must have a boolean visibility value."), 400
+
+    prefs_json_string = json.dumps(new_prefs_payload)
+    db = get_db()
+    try:
+        db.execute("UPDATE users SET column_visibility_prefs = ? WHERE id = ?", (prefs_json_string, user_id))
+        log_audit_action(
+            action_type='UPDATE_COLUMN_VISIBILITY_PREFS',
+            target_table='users',
+            target_id=user_id,
+            details={'message': 'User column visibility preferences updated.'}
+            # Not logging the full prefs JSON in audit for brevity.
+        )
+        db.commit()
+        return jsonify(msg="Column visibility preferences updated successfully."), 200
+    except sqlite3.Error as e:
+        db.rollback()
+        app.logger.error(f"Database error updating column_visibility_prefs for user {user_id}: {e}")
+        return jsonify(msg="Failed to update column visibility preferences due to a database error."), 500
+    except Exception as e:
+        db.rollback()
+        app.logger.error(f"Unexpected error updating column_visibility_prefs for user {user_id}: {e}")
+        return jsonify(msg="An unexpected server error occurred."), 500
+
 @app.route('/api/admin/feedback', methods=['GET'])
 @admin_required
 def admin_get_feedback():

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -29,22 +29,17 @@ interface AuthContextType {
   revokeGlobalAccess: () => void; 
   isPasswordResetRequired: boolean;
   clearPasswordResetRequiredFlag: () => void;
-  // Session Timeout Warning - REMOVED
-  // isSessionWarningModalOpen: boolean;
-  // setSessionWarningModalOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  // sessionWarningCountdown: number;
-  // refreshSession: () => Promise<void>;
+  columnVisibilityPrefs: Record<string, Record<string, boolean>>;
+  updateColumnVisibilityPrefs: (newPrefs: Record<string, Record<string, boolean>>) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
-// REMOVED const PLACEHOLDER_SESSION_DURATION_SECONDS = 15 * 60; // 15 minutes
-// REMOVED const WARNING_THRESHOLD_SECONDS = 2 * 60; // Show warning 2 minutes before expiry
-
 export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
   const [tokenData, setTokenData] = useState<TokenData | null>(null);
   const [user, setUser] = useState<{ id: number; username: string; role: string; profile_picture_url?: string | null; } | null>(null); // Added profile_picture_url
-  const [isLoading, setIsLoading] = useState<boolean>(true); 
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [columnVisibilityPrefs, setColumnVisibilityPrefs] = useState<Record<string, Record<string, boolean>>>({});
   
   const [isAuthModalOpen, setIsAuthModalOpen] = useState<boolean>(false);
   const [authModalView, setAuthModalView] = useState<'login' | 'register'>('login');
@@ -75,13 +70,29 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
   const [isPasswordResetRequired, setIsPasswordResetRequired] = useState<boolean>(false);
   const sessionExpiredToastShownRef = useRef(false); // Added ref
 
+  const fetchColumnVisibilityPrefs = useCallback(async (token: string) => {
+    try {
+      const response = await fetch('/api/user/profile/column-prefs', {
+        headers: { 'Authorization': `Bearer ${token}` }
+      });
+      if (!response.ok) {
+        throw new Error('Failed to fetch column preferences');
+      }
+      const prefs = await response.json();
+      setColumnVisibilityPrefs(prefs || {});
+    } catch (error) {
+      console.error("Error fetching column visibility preferences:", error);
+      setColumnVisibilityPrefs({}); // Default to empty if error
+    }
+  }, []);
+
   // Define logout function using useCallback to ensure stable reference
   const logout = useCallback((sessionExpiredDueToTimeout: boolean = false) => {
     localStorage.removeItem('tokenData');
     setUser(null); // Added
     setTokenData(null);
+    setColumnVisibilityPrefs({}); // Clear prefs on logout
     setIsPasswordResetRequired(false);
-    // setSessionWarningModalOpen(false); // REMOVED: Close warning modal on logout
     
     if (sessionExpiredDueToTimeout) {
       if (!sessionExpiredToastShownRef.current) {
@@ -129,18 +140,21 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
             role: parsedTokenData.role,
             profile_picture_url: parsedTokenData.profile_picture_url || null // Load profile picture URL
           });
+          fetchColumnVisibilityPrefs(parsedTokenData.token); // Fetch prefs on initial load
         } else {
           localStorage.removeItem('tokenData'); 
-          setUser(null); 
+          setUser(null);
+          setColumnVisibilityPrefs({});
         }
       } catch (error) {
         console.error("Failed to parse tokenData from localStorage or tokenData invalid:", error);
         localStorage.removeItem('tokenData');
         setUser(null);
+        setColumnVisibilityPrefs({});
       }
     }
     setIsLoading(false);
-  }, []);
+  }, [fetchColumnVisibilityPrefs]);
 
   // Listen for maintenance mode forced logout event
   useEffect(() => {
@@ -207,12 +221,38 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
       role: newRole,
       profile_picture_url: profile_picture_url || null // Set profile picture URL in user state
     });
+    fetchColumnVisibilityPrefs(newToken); // Fetch prefs on login
     setIsPasswordResetRequired(passwordResetRequired);
     sessionExpiredToastShownRef.current = false; 
     return passwordResetRequired;
   };
   
-  // REMOVED refreshSession function
+  const updateColumnVisibilityPrefs = async (newPrefs: Record<string, Record<string, boolean>>) => {
+    if (!tokenData) {
+      showErrorToast("You must be logged in to update preferences.");
+      throw new Error("User not authenticated");
+    }
+    try {
+      const response = await fetch('/api/user/profile/column-prefs', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${tokenData.token}`,
+        },
+        body: JSON.stringify(newPrefs),
+      });
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.msg || 'Failed to update column preferences');
+      }
+      setColumnVisibilityPrefs(newPrefs); // Update local state on success
+      // showSuccessToast("Column visibility preferences updated!"); // Optional: toast on success
+    } catch (error) {
+      console.error("Error updating column visibility preferences:", error);
+      showErrorToast((error as Error).message || "Failed to update preferences.");
+      throw error; // Re-throw to be handled by caller if needed
+    }
+  };
   // const refreshSession = async () => { ... };
 
   const clearPasswordResetRequiredFlag = () => {
@@ -300,6 +340,8 @@ export const AuthProvider: React.FC<{children: ReactNode}> = ({ children }) => {
       revokeGlobalAccess,
       isPasswordResetRequired,
       clearPasswordResetRequiredFlag,
+      columnVisibilityPrefs,
+      updateColumnVisibilityPrefs,
     }}>
       {children}
     </AuthContext.Provider>

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -37,8 +37,8 @@ interface OutletContextType {
 const DocumentsView: React.FC = () => {
   const ITEMS_PER_PAGE = 10;
   const { searchTerm, setSearchTerm } = useOutletContext<OutletContextType>(); 
-const { isAuthenticated, user } = useAuth();
-const role = user?.role; // Access role safely, as user can be null
+  const { isAuthenticated, user, columnVisibilityPrefs } = useAuth(); // Added columnVisibilityPrefs
+  const role = user?.role; // Access role safely, as user can be null
   const [showAddDocumentForm, setShowAddDocumentForm] = useState(false);
   const [editingDocument, setEditingDocument] = useState<DocumentType | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -478,53 +478,47 @@ useEffect(() => {
     finally { setIsMovingSelected(false); setTargetSoftwareForMove(null); }
   };
 
-  const columns: ColumnDef<DocumentType>[] = [
-    { key: 'doc_name', header: 'Name', sortable: true }, { key: 'doc_type', header: 'Type', sortable: true },
+  // Define base columns
+  const baseColumns: ColumnDef<DocumentType>[] = [
+    { key: 'doc_name', header: 'Name', sortable: true },
+    { key: 'doc_type', header: 'Type', sortable: true },
     { key: 'software_name', header: 'Software', sortable: true },
-    {
-      key: 'description',
-      header: 'Description',
-      // render function removed
-    },
+    { key: 'description', header: 'Description' },
     { 
       key: 'download_link', 
       header: 'Download', 
       render: (d: DocumentType) => {
-        // Check if the document is an external link or an uploaded file that is downloadable
-        const canDirectlyDownload = d.is_external_link || d.is_downloadable;
-        // For uploaded files, if is_downloadable is explicitly false, it's not downloadable.
-        // If is_downloadable is undefined (for older data or if backend missed it), default to allowing download for non-external links.
         const isEffectivelyDownloadable = d.is_external_link || d.is_downloadable !== false;
-
-        if (!isEffectivelyDownloadable && !d.is_external_link) { // It's an uploaded file and not downloadable
+        if (!isEffectivelyDownloadable && !d.is_external_link) {
           return (
             <span className="flex items-center text-gray-400 cursor-not-allowed" title="Download not permitted">
               <Download size={14} className="mr-1"/>Link
             </span>
           );
         }
-        // For external links or downloadable files
         return (
           <a 
             href={d.download_link} 
             target={d.is_external_link || !d.download_link?.startsWith('/') ? "_blank" : "_self"} 
             rel="noopener noreferrer" 
-            className={`flex items-center ${canDirectlyDownload ? 'text-blue-600 hover:text-blue-800' : 'text-gray-400 cursor-not-allowed'}`} 
+            className={`flex items-center ${isEffectivelyDownloadable ? 'text-blue-600 hover:text-blue-800' : 'text-gray-400 cursor-not-allowed'}`}
             onClick={(e) => {
-              if (!canDirectlyDownload) e.preventDefault(); // Prevent action if not downloadable
+              if (!isEffectivelyDownloadable) e.preventDefault();
               e.stopPropagation();
             }}
-            title={canDirectlyDownload ? (d.is_external_link ? "Open external link" : "Download file") : "Download not permitted"}
+            title={isEffectivelyDownloadable ? (d.is_external_link ? "Open external link" : "Download file") : "Download not permitted"}
           >
             {d.is_external_link ? <ExternalLink size={14} className="mr-1"/> : <Download size={14} className="mr-1"/>}Link
           </a>
         );
       } 
     },
+    // These columns will be conditionally added based on preferences
     { key: 'uploaded_by_username', header: 'Uploaded By', sortable: true, render: (d: DocumentType) => d.uploaded_by_username||'N/A' },
     { key: 'updated_by_username', header: 'Updated By', sortable: false, render: (d: DocumentType) => d.updated_by_username||'N/A' },
     { key: 'created_at', header: 'Created At', sortable: true, render: (item: DocumentType) => formatToISTLocaleString(item.created_at ?? '') },
     { key: 'updated_at', header: 'Updated At', sortable: true, render: (item: DocumentType) => formatToISTLocaleString(item.updated_at ?? '') },
+    // Actions column is always present
     { key: 'actions' as any, header: 'Actions', render: (d: DocumentType) => (
       <div className="flex space-x-1 items-center">
         {isAuthenticated && (
@@ -557,6 +551,22 @@ useEffect(() => {
       </div>
     )},
   ];
+
+  const columns = useMemo(() => {
+    const userDocumentPrefs = columnVisibilityPrefs?.documents || {};
+    // Columns to be hidden by default if no preference is set or if preference is false
+    const defaultHiddenColumnKeys = ['uploaded_by_username', 'updated_by_username', 'created_at', 'updated_at'];
+
+    return baseColumns.filter(col => {
+      const colKey = col.key as string;
+      if (defaultHiddenColumnKeys.includes(colKey)) {
+        // If it's a default hidden column, it's visible only if the preference is explicitly true
+        return userDocumentPrefs[colKey] === true;
+      }
+      // For other columns, they are visible unless explicitly set to false
+      return userDocumentPrefs[colKey] !== false;
+    });
+  }, [columnVisibilityPrefs, baseColumns]); // Recompute when preferences change or baseColumns definition changes (though baseColumns is static here)
   
   const totalPagesComputed = Math.ceil(totalDocuments / ITEMS_PER_PAGE);
   const loadDocumentsCallback = useCallback(() => { fetchAndSetDocuments(1, true); }, [fetchAndSetDocuments]);

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -27,7 +27,7 @@ interface OutletContextType {
 
 const LinksView: React.FC = () => {
   const { searchTerm, setSearchTerm } = useOutletContext<OutletContextType>();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, columnVisibilityPrefs } = useAuth(); // Added columnVisibilityPrefs
   const role = user?.role; // Access role safely, as user can be null
   const [links, setLinks] = useState<LinkType[]>([]);
   const [softwareList, setSoftwareList] = useState<Software[]>([]);
@@ -380,8 +380,9 @@ const LinksView: React.FC = () => {
     finally { setIsMovingSelected(false); setModalSelectedSoftwareId(null); setModalSelectedVersionId(undefined); }
   };
 
-  const columns: ColumnDef<LinkType>[] = [
-    { key: 'title', header: 'Title', sortable: true }, { key: 'software_name', header: 'Software', sortable: true },
+  const baseColumns: ColumnDef<LinkType>[] = [
+    { key: 'title', header: 'Title', sortable: true },
+    { key: 'software_name', header: 'Software', sortable: true },
     { key: 'version_name', header: 'Version', sortable: true, render: l => l.version_name || 'N/A' },
     {
       key: 'compatible_vms_versions',
@@ -389,48 +390,29 @@ const LinksView: React.FC = () => {
       sortable: true,
       render: (link: LinkType) => {
         const isRelevantSoftware = link.software_name === 'VMS' || link.software_name === 'VA';
-        let content: React.ReactNode = '-'; // Default content
-
+        let content: React.ReactNode = '-';
         if (isRelevantSoftware) {
           if (link.compatible_vms_versions && link.compatible_vms_versions.length > 0) {
-            if (Array.isArray(link.compatible_vms_versions)) {
-              content = link.compatible_vms_versions.join(', ');
-            } else if (typeof link.compatible_vms_versions === 'string') {
-              content = link.compatible_vms_versions;
-            } else {
-              content = 'N/A';
-            }
-          } else {
-            content = 'N/A';
-          }
+            if (Array.isArray(link.compatible_vms_versions)) content = link.compatible_vms_versions.join(', ');
+            else if (typeof link.compatible_vms_versions === 'string') content = link.compatible_vms_versions;
+            else content = 'N/A';
+          } else content = 'N/A';
         }
-        // Wrap the content in a div with text-center
-        // This div will take up the full width of the cell, and its content will be centered.
         return <div className="text-center">{content}</div>;
       }
     },
-    {
-      key: 'description',
-      header: 'Description',
-      // render function removed
-    },
+    { key: 'description', header: 'Description' },
     {
       key: 'url',
       header: 'Link',
       render: (l: LinkType) => {
         const isEffectivelyDownloadable = l.is_external_link || l.is_downloadable !== false;
-
-        // The text will now always be "Link"
         const displayText = 'Link';
-
-        // The icon will now always be Download, just like in PatchesView
         const IconComponent = l.is_external_link ? ExternalLink : Download;
-
-        if (!isEffectivelyDownloadable && !l.is_external_link) { // Uploaded file, not downloadable
+        if (!isEffectivelyDownloadable && !l.is_external_link) {
           return (
             <span className="flex items-center text-gray-400 cursor-not-allowed" title="Download not permitted">
-              <IconComponent size={14} className="mr-1 flex-shrink-0" />
-              {displayText}
+              <IconComponent size={14} className="mr-1 flex-shrink-0" />{displayText}
             </span>
           );
         }
@@ -440,15 +422,10 @@ const LinksView: React.FC = () => {
             target={l.is_external_link || !l.url?.startsWith('/') ? "_blank" : "_self"}
             rel="noopener noreferrer"
             className={`flex items-center ${isEffectivelyDownloadable ? 'text-blue-600 hover:text-blue-800' : 'text-gray-400 cursor-not-allowed'}`}
-            onClick={(e) => {
-              if (!isEffectivelyDownloadable) e.preventDefault();
-              e.stopPropagation();
-            }}
-            // Update the title attribute to be more specific to links context, matching PatchesView's logic
+            onClick={(e) => { if (!isEffectivelyDownloadable) e.preventDefault(); e.stopPropagation(); }}
             title={isEffectivelyDownloadable ? (l.is_external_link ? "Open external link" : "Download file") : "Download not permitted"}
           >
-            <IconComponent size={14} className="mr-1 flex-shrink-0" />
-            {displayText}
+            <IconComponent size={14} className="mr-1 flex-shrink-0" />{displayText}
           </a>
         );
       }
@@ -506,6 +483,19 @@ const LinksView: React.FC = () => {
       )
     },
   ];
+
+  const columns = useMemo(() => {
+    const userLinksPrefs = columnVisibilityPrefs?.links || {};
+    const defaultHiddenColumnKeys = ['uploaded_by_username', 'updated_by_username', 'created_at', 'updated_at'];
+
+    return baseColumns.filter(col => {
+      const colKey = col.key as string;
+      if (defaultHiddenColumnKeys.includes(colKey)) {
+        return userLinksPrefs[colKey] === true;
+      }
+      return userLinksPrefs[colKey] !== false;
+    });
+  }, [columnVisibilityPrefs, baseColumns]);
 
   const loadLinksCallback = useCallback(() => { fetchAndSetLinks(1, true); }, [fetchAndSetLinks]);
 

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -37,7 +37,7 @@ interface OutletContextType {
 
 const PatchesView: React.FC = () => {
   const { searchTerm, setSearchTerm } = useOutletContext<OutletContextType>();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, user, columnVisibilityPrefs } = useAuth(); // Added columnVisibilityPrefs
   const role = user?.role; // Access role safely, as user can be null
   const [patches, setPatches] = useState<PatchType[]>([]);
   const [softwareList, setSoftwareList] = useState<Software[]>([]);
@@ -450,57 +450,37 @@ const PatchesView: React.FC = () => {
   };
 
   // const formatDate helper is no longer needed as we use specific utility functions now.
-  const columns: ColumnDef<PatchType>[] = [
-    { key: 'patch_name', header: 'Patch Name', sortable: true }, { key: 'software_name', header: 'Software', sortable: true },
+  const baseColumns: ColumnDef<PatchType>[] = [
+    { key: 'patch_name', header: 'Patch Name', sortable: true },
+    { key: 'software_name', header: 'Software', sortable: true },
     { key: 'version_number', header: 'Version', sortable: true },
     { key: 'patch_by_developer', header: 'Developer', sortable: true, render: p => p.patch_by_developer || '-' },
     {
       key: 'compatible_vms_versions',
       header: 'VMS Compatibility',
-      sortable: true, // Backend supports sorting by this string
+      sortable: true,
       render: (patch: PatchType) => {
-        // software_name is directly available on the PatchType from the backend join
         const isRelevantSoftware = patch.software_name === 'VMS' || patch.software_name === 'VA';
-        let content: React.ReactNode = '-'; // Default content
-
+        let content: React.ReactNode = '-';
         if (isRelevantSoftware) {
           if (patch.compatible_vms_versions && patch.compatible_vms_versions.length > 0) {
-            // If it's an array of strings (version numbers)
-            if (Array.isArray(patch.compatible_vms_versions)) {
-              content = patch.compatible_vms_versions.join(', ');
-            }
-            // If it's a single string (comma-separated, as GROUP_CONCAT produces)
-            // This check might be redundant if frontend type enforces array, but good for safety
-            else if (typeof patch.compatible_vms_versions === 'string') {
-              content = patch.compatible_vms_versions;
-            } else {
-              content = 'N/A'; // VMS/VA but data is in unexpected format or empty
-            }
-          } else {
-            content = 'N/A'; // VMS/VA but no compatibility versions set
-          }
+            if (Array.isArray(patch.compatible_vms_versions)) content = patch.compatible_vms_versions.join(', ');
+            else if (typeof patch.compatible_vms_versions === 'string') content = patch.compatible_vms_versions;
+            else content = 'N/A';
+          } else content = 'N/A';
         }
-        // Wrap the content in a div with text-center for alignment
         return <div className="text-center">{content}</div>;
       }
     },
-    {
-      key: 'description',
-      header: 'Description',
-      // render function removed
-    },
-    { key: 'release_date', header: 'Release Date', sortable: true, render: (item: PatchType) => formatDateDisplay(item.release_date) }, // Stays the same
+    { key: 'description', header: 'Description' },
+    { key: 'release_date', header: 'Release Date', sortable: true, render: (item: PatchType) => formatDateDisplay(item.release_date) },
     {
       key: 'download_link',
       header: 'Link',
       render: (p: PatchType) => {
         const isEffectivelyDownloadable = p.is_external_link || p.is_downloadable !== false;
         if (!isEffectivelyDownloadable && !p.is_external_link) {
-          return (
-            <span className="flex items-center text-gray-400 cursor-not-allowed" title="Download not permitted">
-              <Download size={14} className="mr-1" />Link
-            </span>
-          );
+          return (<span className="flex items-center text-gray-400 cursor-not-allowed" title="Download not permitted"><Download size={14} className="mr-1" />Link</span>);
         }
         return (
           <a
@@ -508,10 +488,7 @@ const PatchesView: React.FC = () => {
             target={p.is_external_link || !p.download_link?.startsWith('/') ? "_blank" : "_self"}
             rel="noopener noreferrer"
             className={`flex items-center ${isEffectivelyDownloadable ? 'text-blue-600 hover:text-blue-800' : 'text-gray-400 cursor-not-allowed'}`}
-            onClick={(e) => {
-              if (!isEffectivelyDownloadable) e.preventDefault();
-              e.stopPropagation();
-            }}
+            onClick={(e) => { if (!isEffectivelyDownloadable) e.preventDefault(); e.stopPropagation(); }}
             title={isEffectivelyDownloadable ? (p.is_external_link ? "Open external link" : "Download patch") : "Download not permitted"}
           >
             {p.is_external_link ? <ExternalLink size={14} className="mr-1" /> : <Download size={14} className="mr-1" />}Link
@@ -572,6 +549,19 @@ const PatchesView: React.FC = () => {
       )
     },
   ];
+
+  const columns = useMemo(() => {
+    const userPatchesPrefs = columnVisibilityPrefs?.patches || {};
+    const defaultHiddenColumnKeys = ['uploaded_by_username', 'updated_by_username', 'created_at', 'updated_at'];
+
+    return baseColumns.filter(col => {
+      const colKey = col.key as string;
+      if (defaultHiddenColumnKeys.includes(colKey)) {
+        return userPatchesPrefs[colKey] === true;
+      }
+      return userPatchesPrefs[colKey] !== false;
+    });
+  }, [columnVisibilityPrefs, baseColumns]);
 
   const loadPatchesCallback = useCallback(() => { fetchAndSetPatches(1, true); }, [fetchAndSetPatches]);
 

--- a/frontend/src/views/UserProfilePage.tsx
+++ b/frontend/src/views/UserProfilePage.tsx
@@ -14,9 +14,12 @@ const UserProfilePage: React.FC = () => {
   const { 
     watchPreferences: contextWatchPreferences,
     isLoading: isLoadingContextWatchPreferences,
-    updatePreference, 
+    updatePreference: updateWatchPreference, // Renamed to avoid conflict
     isWatching 
   } = useWatch();
+  // Column Visibility Preferences from AuthContext
+  const { columnVisibilityPrefs, updateColumnVisibilityPrefs } = useAuth();
+
 
   const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://127.0.0.1:7000';
   // State for Profile Picture
@@ -69,13 +72,58 @@ const UserProfilePage: React.FC = () => {
   };
   type ContentTypeKey = keyof typeof CONTENT_WATCH_CONFIG;
 
+  // Config for toggleable columns
+  const COLUMN_VISIBILITY_CONFIG = {
+    documents: {
+      displayName: 'Documents',
+      columns: {
+        uploaded_by_username: 'Uploaded By',
+        updated_by_username: 'Updated By',
+        created_at: 'Created At',
+        updated_at: 'Updated At',
+      }
+    },
+    patches: {
+      displayName: 'Patches',
+      columns: {
+        uploaded_by_username: 'Uploaded By',
+        updated_by_username: 'Updated By',
+        created_at: 'Created At',
+        updated_at: 'Updated At',
+      }
+    },
+    links: {
+      displayName: 'Links',
+      columns: {
+        // Assuming 'uploaded_by_username' maps to 'Added By' and 'created_at' to 'Created' based on typical table views
+        uploaded_by_username: 'Added By',
+        updated_by_username: 'Updated By',
+        created_at: 'Created',
+        updated_at: 'Updated',
+      }
+    }
+  };
+  type TableKeyForColumnPrefs = keyof typeof COLUMN_VISIBILITY_CONFIG;
+
+
   const handleWatchToggle = async (contentType: ContentTypeKey, category: string | undefined, currentlyWatching: boolean) => {
-    // isSavingWatchPreferences is now isLoadingContextWatchPreferences from context
-    // No need to manually set it here as updatePreference in context will handle its loading state.
-    await updatePreference(contentType, category ?? null, !currentlyWatching);
-    // The context will handle updating its own watchPreferences state,
-    // which will cause this component to re-render with the new state.
-    // Toasts for success/failure are handled by updatePreference in context or can be added here if specific messages are needed.
+    await updateWatchPreference(contentType, category ?? null, !currentlyWatching);
+  };
+
+  const handleColumnVisibilityToggle = async (tableKey: TableKeyForColumnPrefs, columnKey: string, currentVisibility: boolean) => {
+    const newPrefs = JSON.parse(JSON.stringify(columnVisibilityPrefs)); // Deep copy
+    if (!newPrefs[tableKey]) {
+      newPrefs[tableKey] = {};
+    }
+    newPrefs[tableKey][columnKey] = !currentVisibility;
+    try {
+      await updateColumnVisibilityPrefs(newPrefs);
+      // Success toast is optional here as AuthContext might handle it or it might not be desired
+      // showSuccessToast(`Visibility for ${COLUMN_VISIBILITY_CONFIG[tableKey].columns[columnKey]} in ${COLUMN_VISIBILITY_CONFIG[tableKey].displayName} updated.`);
+    } catch (error) {
+      // Error toast is handled by updateColumnVisibilityPrefs in AuthContext
+      // No need to show another one here unless more specific message is needed.
+    }
   };
 
   const handleUsernameChangeSubmit = async (e: React.FormEvent) => {
@@ -344,6 +392,49 @@ const UserProfilePage: React.FC = () => {
         </button>
         {/* Toggle rendering logic is now moved to the modal */}
       </div>
+
+      {/* Column Visibility Preferences Section */}
+      <div className="mb-8 p-6 bg-white dark:bg-gray-800 rounded-lg shadow">
+        <h2 className="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Table Column Display Preferences</h2>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+          Toggle visibility for certain columns in table views. Changes are saved automatically.
+        </p>
+        <div className="space-y-6">
+          {Object.entries(COLUMN_VISIBILITY_CONFIG).map(([tableKey, config]) => (
+            <div key={tableKey}>
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-200 mb-2">{config.displayName}</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                {Object.entries(config.columns).map(([colKey, colDisplayName]) => {
+                  // Determine current visibility: default to true if not specified in prefs (user explicitly hides)
+                  // However, for the columns specified in the requirement, they should default to hidden.
+                  // The requirement is to hide:
+                  // Docs: Uploaded By, Updated By, Created At, Updated At
+                  // Patches: Uploaded By, Updated By, Created At, Updated At
+                  // Links: Added By, Updated By, Created, Updated
+                  // These map to: uploaded_by_username, updated_by_username, created_at, updated_at
+                  const isVisible = columnVisibilityPrefs[tableKey as TableKeyForColumnPrefs]?.[colKey] ?? false;
+
+                  return (
+                    <div key={colKey} className="flex items-center">
+                      <input
+                        type="checkbox"
+                        id={`${tableKey}-${colKey}-visibility`}
+                        checked={isVisible}
+                        onChange={() => handleColumnVisibilityToggle(tableKey as TableKeyForColumnPrefs, colKey, isVisible)}
+                        className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-offset-gray-800 dark:bg-gray-700 dark:border-gray-600"
+                      />
+                      <label htmlFor={`${tableKey}-${colKey}-visibility`} className="ml-2 block text-sm text-gray-900 dark:text-gray-300">
+                        Show {colDisplayName}
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
 
       {/* Feedback Section */}
       <div className="mb-8 p-6 bg-white dark:bg-gray-800 rounded-lg shadow">

--- a/schema.sql
+++ b/schema.sql
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS users (
     is_active BOOLEAN DEFAULT TRUE NOT NULL,
     password_reset_required BOOLEAN DEFAULT FALSE NOT NULL,
     dashboard_layout_prefs TEXT DEFAULT NULL,
+    column_visibility_prefs TEXT DEFAULT NULL, -- Added for user-specific column visibility
     profile_picture_filename TEXT, 
     created_at TIMESTAMP DEFAULT (strftime('%Y-%m-%d %H:%M:%S', 'now', '+05:30')),
     last_seen TIMESTAMP,


### PR DESCRIPTION
- Added `column_visibility_prefs` TEXT column to `users` table.
- Implemented API endpoints (GET and PUT) for managing these preferences.
- Updated AuthContext to fetch, store, and update column visibility settings.
- Added a section in UserProfilePage for users to toggle column visibility for Documents, Patches, and Links tables.
- Modified DocumentsView, PatchesView, and LinksView to dynamically render columns based on user preferences.
- Specified columns (Uploaded By, Updated By, Created At, Updated At for Documents/Patches; Added By, Updated By, Created, Updated for Links) are now hidden by default and can be enabled by the user.