### PR TITLE
feat: Implement autocomplete search suggestions

### DIFF
--- a/app.py
+++ b/app.py
@@ -7657,7 +7657,141 @@ def search_api():
                 app.logger.error(f"Error calculating rank for item ID {current_item_id}, type {item.get('type')}: {e}")
                 item['page_number'] = 1 # Default to 1 on error
 
-        return jsonify(results)
+    return jsonify(results)
+
+
+@app.route('/api/search/suggestions', methods=['GET'])
+@jwt_required(optional=True)
+def search_suggestions_api():
+    SUGGESTIONS_LIMIT = 15 # Max number of suggestions to return
+    query_term = request.args.get('q', '').strip()
+    suggestions = []
+    db = get_db()
+
+    logged_in_user_id = None
+    try:
+        current_user_identity = get_jwt_identity()
+        if current_user_identity:
+            logged_in_user_id = int(current_user_identity)
+    except Exception as e:
+        app.logger.error(f"Error getting user_id in search_suggestions_api: {e}")
+
+    if not query_term or len(query_term) < 2: # Require at least 2 characters for suggestions
+        return jsonify(suggestions)
+
+    # Use a prefix search pattern (term%)
+    search_pattern = f"{query_term.lower()}%"
+
+    # Base permission check clause to be appended in WHERE
+    # Using fp_sugg alias for file_permissions table in suggestions context
+    permission_check_clause = "(fp_sugg.id IS NULL OR fp_sugg.can_view IS NOT FALSE)"
+
+    # Documents
+    # Select id, doc_name as name, 'document' as type
+    # Join with file_permissions as fp_sugg
+    # WHERE (permission_check_clause) AND LOWER(d.doc_name) LIKE ?
+    # ORDER BY d.doc_name LIMIT SUGGESTIONS_LIMIT
+    doc_query = f"""
+        SELECT d.id, d.doc_name AS name, 'document' AS type
+        FROM documents d
+        LEFT JOIN file_permissions fp_sugg ON d.id = fp_sugg.file_id AND fp_sugg.file_type = 'document' AND fp_sugg.user_id = ?
+        WHERE {permission_check_clause} AND LOWER(d.doc_name) LIKE ?
+        ORDER BY LOWER(d.doc_name) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    suggestions.extend([dict(row) for row in db.execute(doc_query, (logged_in_user_id, search_pattern)).fetchall()])
+
+    # Patches
+    patch_query = f"""
+        SELECT p.id, p.patch_name AS name, 'patch' AS type
+        FROM patches p
+        LEFT JOIN file_permissions fp_sugg ON p.id = fp_sugg.file_id AND fp_sugg.file_type = 'patch' AND fp_sugg.user_id = ?
+        WHERE {permission_check_clause} AND LOWER(p.patch_name) LIKE ?
+        ORDER BY LOWER(p.patch_name) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    suggestions.extend([dict(row) for row in db.execute(patch_query, (logged_in_user_id, search_pattern)).fetchall()])
+
+    # Links (only titles)
+    link_query = f"""
+        SELECT l.id, l.title AS name, 'link' AS type
+        FROM links l
+        LEFT JOIN file_permissions fp_sugg ON l.id = fp_sugg.file_id AND fp_sugg.file_type = 'link' AND fp_sugg.user_id = ?
+        WHERE {permission_check_clause} AND LOWER(l.title) LIKE ?
+        ORDER BY LOWER(l.title) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    suggestions.extend([dict(row) for row in db.execute(link_query, (logged_in_user_id, search_pattern)).fetchall()])
+
+    # Misc Files (user_provided_title or original_filename)
+    misc_query = f"""
+        SELECT
+            mf.id,
+            COALESCE(mf.user_provided_title, mf.original_filename) AS name,
+            'misc_file' AS type
+        FROM misc_files mf
+        LEFT JOIN file_permissions fp_sugg ON mf.id = fp_sugg.file_id AND fp_sugg.file_type = 'misc_file' AND fp_sugg.user_id = ?
+        WHERE {permission_check_clause} AND (
+            (mf.user_provided_title IS NOT NULL AND LOWER(mf.user_provided_title) LIKE ?) OR
+            (mf.user_provided_title IS NULL AND LOWER(mf.original_filename) LIKE ?)
+        )
+        ORDER BY LOWER(COALESCE(mf.user_provided_title, mf.original_filename)) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    # For misc_files, the search_pattern needs to be applied twice if COALESCE is split.
+    # If COALESCE is used directly in WHERE, then only one search_pattern.
+    # Example with direct COALESCE in WHERE:
+    misc_query_alt = f"""
+        SELECT
+            mf.id,
+            COALESCE(mf.user_provided_title, mf.original_filename) AS name,
+            'misc_file' AS type
+        FROM misc_files mf
+        LEFT JOIN file_permissions fp_sugg ON mf.id = fp_sugg.file_id AND fp_sugg.file_type = 'misc_file' AND fp_sugg.user_id = ?
+        WHERE {permission_check_clause} AND LOWER(COALESCE(mf.user_provided_title, mf.original_filename)) LIKE ?
+        ORDER BY LOWER(COALESCE(mf.user_provided_title, mf.original_filename)) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    suggestions.extend([dict(row) for row in db.execute(misc_query_alt, (logged_in_user_id, search_pattern)).fetchall()])
+
+    # Software titles
+    software_query = f"""
+        SELECT s.id, s.name, 'software' AS type
+        FROM software s
+        WHERE LOWER(s.name) LIKE ?
+        ORDER BY LOWER(s.name) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    # No file_permissions for software titles themselves, they are metadata.
+    suggestions.extend([dict(row) for row in db.execute(software_query, (search_pattern,)).fetchall()])
+
+    # Versions (version_number)
+    version_query = f"""
+        SELECT v.id, v.version_number AS name, 'version' AS type, v.software_id, s.name as software_name
+        FROM versions v
+        JOIN software s ON v.software_id = s.id
+        WHERE LOWER(v.version_number) LIKE ?
+        ORDER BY LOWER(v.version_number) ASC
+        LIMIT {SUGGESTIONS_LIMIT}
+    """
+    # No file_permissions for version numbers themselves.
+    suggestions.extend([dict(row) for row in db.execute(version_query, (search_pattern,)).fetchall()])
+
+    # Sort all suggestions by name (case-insensitive) and then limit
+    # This is important because we are combining results from multiple queries.
+    # Each query already has a LIMIT, but the combined list might exceed the overall desired limit.
+    # Also, to ensure a consistent order across types.
+
+    # Make sure 'name' key exists and is string for sorting
+    valid_suggestions_for_sort = [s for s in suggestions if isinstance(s.get('name'), str)]
+
+    # Sort by name (case-insensitive)
+    valid_suggestions_for_sort.sort(key=lambda x: x['name'].lower())
+
+    # Limit the final list
+    final_suggestions = valid_suggestions_for_sort[:SUGGESTIONS_LIMIT]
+
+    return jsonify(final_suggestions)
 
 # --- Global Error Handler for ConnectionAbortedError ---
 @app.errorhandler(ConnectionAbortedError)

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,35 +1,110 @@
 // src/components/Header.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Menu, Search, X, LogOut, User, LogIn, Sun, Moon } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useTheme } from '../context/ThemeContext';
 import NotificationBell from './notifications/NotificationBell';
+import { fetchSearchSuggestions, Suggestion } from '../services/api'; // Added
 
 interface HeaderProps {
   toggleSidebar: () => void;
   isCollapsed: boolean;
-  onSearch: (term: string) => void; // Assuming onSearch might still be used elsewhere or for other purposes
+  onSearch: (term: string) => void;
 }
 
 const Header: React.FC<HeaderProps> = ({ toggleSidebar, isCollapsed, onSearch }) => {
   const [searchValue, setSearchValue] = useState('');
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [isSuggestionsLoading, setIsSuggestionsLoading] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const debounceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const searchContainerRef = useRef<HTMLDivElement>(null); // Ref for the search container
+
   const { user, isAuthenticated, logout, openAuthModal } = useAuth();
   const navigate = useNavigate();
   const { themeMode, toggleThemeMode } = useTheme();
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (searchValue.trim()) {
-      navigate(`/search?q=${encodeURIComponent(searchValue.trim())}`);
+  const handleSubmit = (e?: React.FormEvent, navigationValue?: string) => {
+    if (e) e.preventDefault();
+    const termToSearch = navigationValue || searchValue;
+    if (termToSearch.trim()) {
+      navigate(`/search?q=${encodeURIComponent(termToSearch.trim())}`);
+      setSuggestions([]);
+      setShowSuggestions(false);
     }
   };
 
   const clearSearch = () => {
     setSearchValue('');
-    // Optional: if onSearch was used to clear results, ensure that's handled
-    // if (location.pathname.startsWith('/search')) navigate('/documents'); // Example
+    setSuggestions([]);
+    setShowSuggestions(false);
   };
+
+  const handleSuggestionClick = (suggestion: Suggestion) => {
+    setSearchValue(suggestion.name);
+    setSuggestions([]);
+    setShowSuggestions(false);
+    // Navigate to a generic search results page with the suggestion name as query
+    // A more advanced implementation could navigate directly to the item if type and ID are known
+    // e.g., if (suggestion.type === 'document') navigate(`/documents/${suggestion.id}`);
+    handleSubmit(undefined, suggestion.name);
+  };
+
+  // Debounced fetch function
+  const debouncedFetchSuggestions = useCallback((term: string) => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+    }
+    debounceTimeoutRef.current = setTimeout(async () => {
+      if (term.trim().length >= 2) {
+        setIsSuggestionsLoading(true);
+        try {
+          const fetchedSuggestions = await fetchSearchSuggestions(term);
+          setSuggestions(fetchedSuggestions);
+          setShowSuggestions(true); // Show suggestions when they are fetched
+        } catch (error) {
+          console.error("Failed to fetch search suggestions:", error);
+          setSuggestions([]);
+          setShowSuggestions(false); // Hide on error
+        } finally {
+          setIsSuggestionsLoading(false);
+        }
+      } else {
+        setSuggestions([]);
+        setShowSuggestions(false); // Hide if term is too short
+      }
+    }, 300); // 300ms debounce delay
+  }, []); // Empty dependency array means this function is created once
+
+  const handleSearchInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const term = e.target.value;
+    setSearchValue(term);
+    if (term.trim().length >= 2) {
+      debouncedFetchSuggestions(term);
+    } else {
+      if (debounceTimeoutRef.current) clearTimeout(debounceTimeoutRef.current);
+      setSuggestions([]);
+      setShowSuggestions(false);
+    }
+  };
+
+  // Effect to handle clicks outside the search suggestions dropdown
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (searchContainerRef.current && !searchContainerRef.current.contains(event.target as Node)) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      if (debounceTimeoutRef.current) { // Clear timeout on unmount
+        clearTimeout(debounceTimeoutRef.current);
+      }
+    };
+  }, []);
+
 
   const handleLogout = () => {
     logout();
@@ -54,7 +129,7 @@ const Header: React.FC<HeaderProps> = ({ toggleSidebar, isCollapsed, onSearch })
         </div>
 
         {/* Center Section: Search Bar */}
-        <div className="flex-1 flex justify-center px-4">
+        <div className="flex-1 flex justify-center px-4" ref={searchContainerRef}>
           <form
             onSubmit={handleSubmit}
             className="relative w-full max-w-lg"
@@ -67,7 +142,9 @@ const Header: React.FC<HeaderProps> = ({ toggleSidebar, isCollapsed, onSearch })
                 type="text"
                 placeholder="Search..."
                 value={searchValue}
-                onChange={(e) => setSearchValue(e.target.value)}
+                onChange={handleSearchInputChange}
+                onFocus={() => { if (suggestions.length > 0) setShowSuggestions(true);}}
+                // onBlur={() => setTimeout(() => setShowSuggestions(false), 100)} // Delay to allow click on suggestion
                 className="block w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200 dark:placeholder-gray-400 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-all"
               />
               {searchValue && (
@@ -81,6 +158,32 @@ const Header: React.FC<HeaderProps> = ({ toggleSidebar, isCollapsed, onSearch })
                 </button>
               )}
             </div>
+            {showSuggestions && suggestions.length > 0 && (
+              <ul className="absolute z-10 w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md mt-1 shadow-lg max-h-60 overflow-auto">
+                {isSuggestionsLoading ? (
+                  <li className="px-4 py-2 text-gray-500 dark:text-gray-400">Loading...</li>
+                ) : (
+                  suggestions.map((suggestion, index) => (
+                    <li
+                      key={`${suggestion.id}-${index}`}
+                      onMouseDown={(e) => { // Use onMouseDown to fire before onBlur on input
+                        e.preventDefault(); // Prevent input from losing focus immediately
+                        handleSuggestionClick(suggestion);
+                      }}
+                      className="px-4 py-2 hover:bg-gray-100 dark:hover:bg-gray-600 cursor-pointer text-sm text-gray-700 dark:text-gray-200"
+                    >
+                      {suggestion.name}
+                      <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">({suggestion.type})</span>
+                    </li>
+                  ))
+                )}
+              </ul>
+            )}
+             {showSuggestions && !isSuggestionsLoading && suggestions.length === 0 && searchValue.length >= 2 && (
+                <div className="absolute z-10 w-full bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md mt-1 shadow-lg p-4 text-center">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">No suggestions found.</p>
+                </div>
+            )}
           </form>
         </div>
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -933,6 +933,41 @@ export function bulkDownloadItems(itemIds: number[], itemType: BulkItemType): Pr
   });
 }
 
+// --- Search Suggestions ---
+export interface Suggestion {
+  id: number | string;
+  name: string;
+  type: string;
+  software_id?: number; // Optional: For version suggestions
+  software_name?: string; // Optional: For version suggestions
+}
+
+export async function fetchSearchSuggestions(query: string): Promise<Suggestion[]> {
+  if (!query || query.trim().length < 2) {
+    return Promise.resolve([]); // Don't call API for very short queries
+  }
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/search/suggestions?q=${encodeURIComponent(query)}`, {
+      method: 'GET',
+      headers: {
+        ...getAuthHeader(), // Include auth header if available, for permissioned suggestions
+        'Cache-Control': 'no-cache',
+        'Pragma': 'no-cache',
+      },
+    });
+    // Using handleApiError for consistent processing
+    return handleApiError(response, 'Failed to fetch search suggestions');
+  } catch (error: any) {
+    if (error instanceof TypeError && error.message.toLowerCase().includes('failed to fetch')) {
+      setGlobalOfflineStatus(true);
+      showErrorToast(OFFLINE_MESSAGE);
+    }
+    console.error('Error fetching search suggestions:', error);
+    throw error; // Re-throw to be handled by the calling component
+  }
+}
+// --- End Search Suggestions ---
+
 /**
  * Performs a bulk move operation on specified items.
  * @param itemIds - An array of item IDs to move.


### PR DESCRIPTION
Implemented an autocomplete/typeahead feature for the main search bar.

Backend:
- Added a new endpoint `/api/search/suggestions` in `app.py`.
- This endpoint performs prefix-based searches across documents, patches, links, misc_files, software, and versions.
- It respects view permissions for suggestions and returns a limited, sorted list of suggestions with `id`, `name`, and `type`.

Frontend:
- Added `fetchSearchSuggestions` to `services/api.ts` to call the new backend endpoint.
- Updated `Header.tsx` to:
  - Fetch and display suggestions in a dropdown as the user types.
  - Implemented debouncing for API calls to improve performance.
  - Allow users to click on a suggestion to populate the search bar and navigate to the search results for that term.
  - Added basic styling for the suggestions dropdown.
- Defined a `Suggestion` interface for the type of suggestion objects.

The feature provides real-time search suggestions to enhance user experience when searching for files or items within the application.