### PR TITLE
feat: Implement autocomplete, direct navigation, and scroll-to-highlight

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -36,6 +36,7 @@ interface DataTableProps<T> {
   selectedItemIds?: Set<number>;
   onSelectItem?: (itemId: number, isSelected: boolean) => void;
   onSelectAllItems?: (isSelected: boolean) => void;
+  itemTypePrefix?: string; // New prop for data-item-id prefix
 }
 
 // Ensure T has an 'id' property of type number for selection logic
@@ -58,6 +59,7 @@ const DataTable = <T extends { id: number }>({
   onSelectItem,
   onSelectAllItems,
   highlightedRowId = null, // Added prop with default
+  itemTypePrefix = 'item', // Default prefix if not provided
 }: DataTableProps<T>) => {
   const [showFullDescriptionModal, setShowFullDescriptionModal] = useState(false);
   const [fullDescription, setFullDescription] = useState('');
@@ -207,6 +209,7 @@ const DataTable = <T extends { id: number }>({
               return (
                 <tr
                   key={item.id || index}
+                  data-item-id={`${itemTypePrefix}-${item.id}`} // Use the new prop
                   className={`transition-colors 
                             ${customRowClass || ''} 
                             ${isSelected ? 'bg-sky-100 dark:bg-sky-800 hover:bg-sky-200 dark:hover:bg-sky-700' : 'hover:bg-gray-50 dark:hover:bg-gray-700'}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -42,13 +42,46 @@ const Header: React.FC<HeaderProps> = ({ toggleSidebar, isCollapsed, onSearch })
   };
 
   const handleSuggestionClick = (suggestion: Suggestion) => {
-    setSearchValue(suggestion.name);
+    // Clear search input and hide suggestions immediately
+    setSearchValue('');
     setSuggestions([]);
     setShowSuggestions(false);
-    // Navigate to a generic search results page with the suggestion name as query
-    // A more advanced implementation could navigate directly to the item if type and ID are known
-    // e.g., if (suggestion.type === 'document') navigate(`/documents/${suggestion.id}`);
-    handleSubmit(undefined, suggestion.name);
+
+    const { id, type, software_id, name } = suggestion;
+
+    switch (type) {
+      case 'document':
+        navigate(`/documents?highlight=${id}`);
+        break;
+      case 'patch':
+        navigate(`/patches?highlight=${id}`);
+        break;
+      case 'link':
+        navigate(`/links?highlight=${id}`);
+        break;
+      case 'misc_file':
+        navigate(`/misc?highlight=${id}`);
+        break;
+      case 'software':
+        // Assuming software suggestions should link to a page listing its documents or a general software view
+        navigate(`/documents?software_id=${id}`);
+        break;
+      case 'version':
+        // Versions are often associated with a specific software's patches or documents
+        // Using software_id from the suggestion is crucial here.
+        if (software_id) {
+          navigate(`/patches?software_id=${software_id}&version_id=${id}`);
+        } else {
+          // Fallback if software_id is somehow missing for a version suggestion, though backend should provide it.
+          console.warn(`Software ID missing for version suggestion: ${name}`);
+          navigate(`/search?q=${encodeURIComponent(name)}`);
+        }
+        break;
+      default:
+        // Fallback for unknown types: perform a general search
+        navigate(`/search?q=${encodeURIComponent(name)}`);
+        break;
+    }
   };
 
   // Debounced fetch function
@@ -59,18 +92,21 @@ const Header: React.FC<HeaderProps> = ({ toggleSidebar, isCollapsed, onSearch })
     debounceTimeoutRef.current = setTimeout(async () => {
       if (term.trim().length >= 2) {
         setIsSuggestionsLoading(true);
+        console.log(`[Autocomplete] Debounced: Fetching suggestions for term: "${term}"`); // DEBUG
         try {
           const fetchedSuggestions = await fetchSearchSuggestions(term);
+          console.log("[Autocomplete] Fetched suggestions:", fetchedSuggestions); // DEBUG
           setSuggestions(fetchedSuggestions);
           setShowSuggestions(true); // Show suggestions when they are fetched
         } catch (error) {
-          console.error("Failed to fetch search suggestions:", error);
+          console.error("[Autocomplete] Failed to fetch search suggestions:", error); // DEBUG
           setSuggestions([]);
           setShowSuggestions(false); // Hide on error
         } finally {
           setIsSuggestionsLoading(false);
         }
       } else {
+        console.log(`[Autocomplete] Debounced: Term "${term}" too short, clearing suggestions.`); // DEBUG
         setSuggestions([]);
         setShowSuggestions(false); // Hide if term is too short
       }

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -304,10 +304,23 @@ useEffect(() => {
 
     if (highlightIdFromUrl) {
       setHighlightedItemId(highlightIdFromUrl);
+      // Scroll to highlighted item after data is potentially loaded/updated
+      setTimeout(() => {
+        // Use the correct prefix for documents
+        const element = document.querySelector(`[data-item-id="document-${highlightIdFromUrl}"]`);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          // Optional: Add a class for a temporary visual cue, then remove it
+          // element.classList.add('ring-2', 'ring-offset-2', 'ring-indigo-500');
+          // setTimeout(() => element.classList.remove('ring-2', 'ring-offset-2', 'ring-indigo-500'), 2000);
+        } else {
+          // console.warn(`DocumentsView: Element with data-item-id="document-${highlightIdFromUrl}" not found for scrolling.`);
+        }
+      }, 150); // Increased delay slightly
     } else {
       setHighlightedItemId(null); // Clear highlight if not in URL
     }
-  }, [searchParams, currentPage, setCurrentPage, fetchAndSetDocuments]);
+  }, [searchParams, documents, fetchAndSetDocuments]); // Ensure fetchAndSetDocuments is here if page change triggers re-fetch
 
 const handleFilterChange = (softwareId: number | null) => {
     setHighlightedItemId(null); // Clear highlight
@@ -318,17 +331,22 @@ const handleFilterChange = (softwareId: number | null) => {
 // This useEffect is where the actual fetch happens
 // Already modified to include setHighlightedItemId(null)
 useEffect(() => {
-    setHighlightedItemId(null); 
+    // setHighlightedItemId(null); // This was moved to individual filter/sort handlers
     if (!isAuthenticated) {
         setDocuments([]); setFavoritedItems(new Map()); setCurrentPage(1);
         setHasMore(false); setIsLoadingInitial(false); return;
     }
-    fetchAndSetDocuments(1, true);
+    // Check if page is being set by URL param, if so, fetchAndSetDocuments will be called by that effect.
+    // This prevents double fetching if both page and other filters change.
+    const pageFromUrlStr = searchParams.get('page');
+    if (!pageFromUrlStr) { // Only fetch if page is not being driven by URL param initially
+        fetchAndSetDocuments(1, true);
+    }
 }, [
     isAuthenticated, selectedSoftwareId, sortBy, sortOrder,
     debouncedDocTypeFilter, debouncedCreatedFromFilter, debouncedCreatedToFilter,
     debouncedUpdatedFromFilter, debouncedUpdatedToFilter, searchTerm,
-    fetchAndSetDocuments, setHighlightedItemId
+    fetchAndSetDocuments, searchParams // Added searchParams here
 ]);
   const handleSort = (columnKey: string) => {
     setHighlightedItemId(null); // Clear highlight
@@ -677,7 +695,26 @@ useEffect(() => {
           {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 text-sm font-medium">Clear All Filters & Search</button>)}
         </div>
       ) : (
-        <DataTable columns={columns} data={filteredDocumentsBySearch} highlightedRowId={highlightedItemId} rowClassName="group" isLoading={isLoadingInitial||isLoadingMore} currentPage={currentPage} totalPages={totalPagesComputed} onPageChange={handlePageChange} itemsPerPage={ITEMS_PER_PAGE} totalItems={totalDocuments} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedDocumentIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
+        <DataTable
+          itemTypePrefix="document" // Added prefix for documents
+          columns={columns}
+          data={filteredDocumentsBySearch}
+          highlightedRowId={highlightedItemId}
+          rowClassName="group"
+          isLoading={isLoadingInitial||isLoadingMore}
+          currentPage={currentPage}
+          totalPages={totalPagesComputed}
+          onPageChange={handlePageChange}
+          itemsPerPage={ITEMS_PER_PAGE}
+          totalItems={totalDocuments}
+          sortColumn={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
+          isSelectionEnabled={true}
+          selectedItemIds={selectedDocumentIds}
+          onSelectItem={handleSelectItem}
+          onSelectAllItems={handleSelectAllItems}
+        />
       )}
       {showDeleteConfirm && documentToDelete && (<ConfirmationModal isOpen={showDeleteConfirm} title="Delete Document" message={`Delete "${documentToDelete.doc_name}"?`} onConfirm={handleDeleteConfirm} onCancel={closeDeleteConfirm} isConfirming={isDeleting} confirmButtonText="Delete" confirmButtonVariant="danger"/>)}
       {showBulkDeleteConfirmModal && (<ConfirmationModal isOpen={showBulkDeleteConfirmModal} title={`Delete ${selectedDocumentIds.size} Document(s)`} message={`Delete ${selectedDocumentIds.size} selected items?`} onConfirm={confirmBulkDelete} onCancel={()=>setShowBulkDeleteConfirmModal(false)} isConfirming={isDeletingSelected} confirmButtonText="Delete Selected" confirmButtonVariant="danger"/>)}

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -171,10 +171,17 @@ const LinksView: React.FC = () => {
 
     if (highlightIdFromUrl) {
       setHighlightedItemId(highlightIdFromUrl);
+      // Scroll to highlighted item
+      setTimeout(() => {
+        const element = document.querySelector(`[data-item-id="link-${highlightIdFromUrl}"]`);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 150);
     } else {
       setHighlightedItemId(null); 
     }
-  }, [searchParams, currentPage, setCurrentPage, fetchAndSetLinks]);
+  }, [searchParams, links, fetchAndSetLinks]); // Added links and fetchAndSetLinks
 
   // Effect to handle focusing on a comment if item_id and comment_id are in URL
   useEffect(() => {
@@ -630,7 +637,26 @@ const LinksView: React.FC = () => {
           {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 btn-primary text-sm">Clear All Filters & Search</button>)}
         </div>
       ) : (
-        <DataTable columns={columns} data={links} highlightedRowId={highlightedItemId} rowClassName="group" isLoading={isLoadingInitial || isProcessingSingleItem} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalLinks} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedLinkIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
+        <DataTable
+          itemTypePrefix="link" // Added prefix for links
+          columns={columns}
+          data={links}
+          highlightedRowId={highlightedItemId}
+          rowClassName="group"
+          isLoading={isLoadingInitial || isProcessingSingleItem}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+          itemsPerPage={itemsPerPage}
+          totalItems={totalLinks}
+          sortColumn={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
+          isSelectionEnabled={true}
+          selectedItemIds={selectedLinkIds}
+          onSelectItem={handleSelectItem}
+          onSelectAllItems={handleSelectAllItems}
+        />
       )}
 
       {showDeleteConfirm && linkToDelete && (<ConfirmationModal isOpen={showDeleteConfirm} title="Delete Link" message={`Delete "${linkToDelete.title}"?`} onConfirm={handleDeleteLinkConfirm} onCancel={closeDeleteConfirm} isConfirming={isProcessingSingleItem} confirmButtonText="Delete" confirmButtonVariant="danger" />)}

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -166,10 +166,17 @@ const role = user?.role; // Access role safely, as user can be null
 
     if (highlightIdFromUrl) {
       setHighlightedItemId(highlightIdFromUrl);
+      // Scroll to highlighted item
+      setTimeout(() => {
+        const element = document.querySelector(`[data-item-id="misc_file-${highlightIdFromUrl}"]`);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 150);
     } else {
       setHighlightedItemId(null);
     }
-  }, [searchParams, currentPage, setCurrentPage, fetchAndSetMiscFiles]);
+  }, [searchParams, miscFiles, fetchAndSetMiscFiles]); // Added miscFiles and fetchAndSetMiscFiles
 
   // Effect to handle focusing on a comment if item_id and comment_id are in URL
   useEffect(() => {
@@ -566,7 +573,26 @@ const role = user?.role; // Access role safely, as user can be null
             {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 btn-primary text-sm">Clear All Filters & Search</button>)}
           </div>
         ) : (
-        <DataTable columns={columns} data={miscFiles} highlightedRowId={highlightedItemId} rowClassName="group" isLoading={isLoadingInitial || isProcessingSingleItem} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalMiscFiles} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedMiscFileIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
+        <DataTable
+          itemTypePrefix="misc_file" // Added prefix for misc files
+          columns={columns}
+          data={miscFiles}
+          highlightedRowId={highlightedItemId}
+          rowClassName="group"
+          isLoading={isLoadingInitial || isProcessingSingleItem}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+          itemsPerPage={itemsPerPage}
+          totalItems={totalMiscFiles}
+          sortColumn={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
+          isSelectionEnabled={true}
+          selectedItemIds={selectedMiscFileIds}
+          onSelectItem={handleSelectItem}
+          onSelectAllItems={handleSelectAllItems}
+        />
       )}
 
       {showDeleteCategoryConfirm && categoryToDelete && (<ConfirmationModal isOpen={showDeleteCategoryConfirm} title="Delete Category" message={`Delete category "${categoryToDelete.name}"? Files in it won't be deleted but will become uncategorized.`} onConfirm={handleDeleteCategoryConfirm} onCancel={closeDeleteCategoryConfirm} isConfirming={isProcessingCategory} confirmButtonText="Delete" confirmButtonVariant="danger"/>)}

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -210,10 +210,17 @@ const PatchesView: React.FC = () => {
 
     if (highlightIdFromUrl) {
       setHighlightedItemId(highlightIdFromUrl);
+      // Scroll to highlighted item
+      setTimeout(() => {
+        const element = document.querySelector(`[data-item-id="patch-${highlightIdFromUrl}"]`);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      }, 150);
     } else {
       setHighlightedItemId(null);
     }
-  }, [searchParams, currentPage, setCurrentPage, fetchAndSetPatches]);
+  }, [searchParams, patches, fetchAndSetPatches]); // Added patches and fetchAndSetPatches
 
   useEffect(() => {
     const queryParams = new URLSearchParams(location.search);
@@ -673,7 +680,26 @@ const PatchesView: React.FC = () => {
           {filtersAreActive && (<button onClick={handleClearAllFiltersAndSearch} className="mt-6 btn-primary text-sm">Clear All Filters & Search</button>)}
         </div>
       ) : (
-        <DataTable columns={columns} data={filteredPatchesBySearch} highlightedRowId={highlightedItemId} rowClassName="group" isLoading={isLoadingInitial || isProcessingSingleItem} currentPage={currentPage} totalPages={totalPages} onPageChange={handlePageChange} itemsPerPage={itemsPerPage} totalItems={totalPatches} sortColumn={sortBy} sortOrder={sortOrder} onSort={handleSort} isSelectionEnabled={true} selectedItemIds={selectedPatchIds} onSelectItem={handleSelectItem} onSelectAllItems={handleSelectAllItems} />
+        <DataTable
+          itemTypePrefix="patch" // Added prefix for patches
+          columns={columns}
+          data={filteredPatchesBySearch}
+          highlightedRowId={highlightedItemId}
+          rowClassName="group"
+          isLoading={isLoadingInitial || isProcessingSingleItem}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={handlePageChange}
+          itemsPerPage={itemsPerPage}
+          totalItems={totalPatches}
+          sortColumn={sortBy}
+          sortOrder={sortOrder}
+          onSort={handleSort}
+          isSelectionEnabled={true}
+          selectedItemIds={selectedPatchIds}
+          onSelectItem={handleSelectItem}
+          onSelectAllItems={handleSelectAllItems}
+        />
       )}
 
       {showDeleteConfirm && patchToDelete && (<ConfirmationModal isOpen={showDeleteConfirm} title="Delete Patch" message={`Delete "${patchToDelete.patch_name}"?`} onConfirm={handleDeleteConfirm} onCancel={closeDeleteConfirm} isConfirming={isProcessingSingleItem} confirmButtonText="Delete" confirmButtonVariant="danger" />)}


### PR DESCRIPTION
This commit introduces several enhancements to the search functionality:

1.  **Autocomplete Search Suggestions:**
    *   Added a backend endpoint (`/api/search/suggestions`) to provide real-time search suggestions.
    *   The frontend `Header` component now fetches and displays these suggestions in a dropdown as the user types, with debouncing to optimize performance.

2.  **Direct Navigation from Suggestions:**
    *   Clicking on a search suggestion now navigates the user directly to the relevant item's page (e.g., Document view, Patch view) instead of just re-running the search.

3.  **Scroll-to-Highlight:**
    *   When navigating to a view with a `highlight=<ITEM_ID>` URL parameter (e.g., after clicking a suggestion), the page will now automatically scroll to bring the highlighted item into view if it's not immediately visible.
    *   This functionality has been implemented in `DocumentsView`, `PatchesView`, `LinksView`, and `MiscView`.
    *   The `DataTable` component was updated to support this by adding a `data-item-id` attribute to rows via a new `itemTypePrefix` prop.

These changes aim to improve the search user experience by making it faster and more intuitive to find and navigate to specific items.