### PR TITLE
feat: Implement search UX, admin, and backup enhancements

### DIFF
--- a/frontend/src/components/Breadcrumbs.tsx
+++ b/frontend/src/components/Breadcrumbs.tsx
@@ -38,11 +38,17 @@ const Breadcrumbs: React.FC = () => {
         </MuiLink>
         {pathnames.map((value, index) => {
           const last = index === pathnames.length - 1;
-          const to = `/${pathnames.slice(0, index + 1).join('/')}`;
+          let to = `/${pathnames.slice(0, index + 1).join('/')}`;
           const formattedName = formatSegment(value);
 
+          // If the current segment is 'admin' and it's not the last segment,
+          // make its link point to '/admin/dashboard'.
+          if (value === 'admin' && !last) {
+            to = '/admin/dashboard';
+          }
+
           return last ? (
-            <Typography color="text.primary" key={to}>
+            <Typography color="text.primary" key={to}> {/* Key might need adjustment if 'to' changes for 'admin' */}
               {formattedName}
             </Typography>
           ) : (

--- a/frontend/src/views/DocumentsView.tsx
+++ b/frontend/src/views/DocumentsView.tsx
@@ -310,17 +310,22 @@ useEffect(() => {
         const element = document.querySelector(`[data-item-id="document-${highlightIdFromUrl}"]`);
         if (element) {
           element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          // Optional: Add a class for a temporary visual cue, then remove it
-          // element.classList.add('ring-2', 'ring-offset-2', 'ring-indigo-500');
-          // setTimeout(() => element.classList.remove('ring-2', 'ring-offset-2', 'ring-indigo-500'), 2000);
+          // Remove highlight from URL after scrolling
+          const newSearchParams = new URLSearchParams(searchParams);
+          newSearchParams.delete('highlight');
+          setSearchParams(newSearchParams, { replace: true });
         } else {
           // console.warn(`DocumentsView: Element with data-item-id="document-${highlightIdFromUrl}" not found for scrolling.`);
+          // If element not found, still remove the highlight param as it's not useful
+          const newSearchParams = new URLSearchParams(searchParams);
+          newSearchParams.delete('highlight');
+          setSearchParams(newSearchParams, { replace: true });
         }
-      }, 150); // Increased delay slightly
+      }, 150);
     } else {
-      setHighlightedItemId(null); // Clear highlight if not in URL
+      setHighlightedItemId(null);
     }
-  }, [searchParams, documents, fetchAndSetDocuments]); // Ensure fetchAndSetDocuments is here if page change triggers re-fetch
+  }, [searchParams, documents, fetchAndSetDocuments, setSearchParams]);
 
 const handleFilterChange = (softwareId: number | null) => {
     setHighlightedItemId(null); // Clear highlight

--- a/frontend/src/views/LinksView.tsx
+++ b/frontend/src/views/LinksView.tsx
@@ -177,11 +177,15 @@ const LinksView: React.FC = () => {
         if (element) {
           element.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
+        // Always remove the highlight param after attempting to scroll or if not found
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.delete('highlight');
+        setSearchParams(newSearchParams, { replace: true });
       }, 150);
     } else {
       setHighlightedItemId(null); 
     }
-  }, [searchParams, links, fetchAndSetLinks]); // Added links and fetchAndSetLinks
+  }, [searchParams, links, fetchAndSetLinks, setSearchParams]);
 
   // Effect to handle focusing on a comment if item_id and comment_id are in URL
   useEffect(() => {

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -172,11 +172,15 @@ const role = user?.role; // Access role safely, as user can be null
         if (element) {
           element.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
+        // Always remove the highlight param after attempting to scroll or if not found
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.delete('highlight');
+        setSearchParams(newSearchParams, { replace: true });
       }, 150);
     } else {
       setHighlightedItemId(null);
     }
-  }, [searchParams, miscFiles, fetchAndSetMiscFiles]); // Added miscFiles and fetchAndSetMiscFiles
+  }, [searchParams, miscFiles, fetchAndSetMiscFiles, setSearchParams]);
 
   // Effect to handle focusing on a comment if item_id and comment_id are in URL
   useEffect(() => {
@@ -574,7 +578,7 @@ const role = user?.role; // Access role safely, as user can be null
           </div>
         ) : (
         <DataTable
-          itemTypePrefix="misc_file" // Added prefix for misc files
+          itemTypePrefix="misc_file"
           columns={columns}
           data={miscFiles}
           highlightedRowId={highlightedItemId}

--- a/frontend/src/views/PatchesView.tsx
+++ b/frontend/src/views/PatchesView.tsx
@@ -216,11 +216,15 @@ const PatchesView: React.FC = () => {
         if (element) {
           element.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
+        // Always remove the highlight param after attempting to scroll or if not found
+        const newSearchParams = new URLSearchParams(searchParams);
+        newSearchParams.delete('highlight');
+        setSearchParams(newSearchParams, { replace: true });
       }, 150);
     } else {
       setHighlightedItemId(null);
     }
-  }, [searchParams, patches, fetchAndSetPatches]); // Added patches and fetchAndSetPatches
+  }, [searchParams, patches, fetchAndSetPatches, setSearchParams]);
 
   useEffect(() => {
     const queryParams = new URLSearchParams(location.search);


### PR DESCRIPTION
This commit includes several features and fixes:

1.  **Search Autocomplete & Direct Navigation:**
    *   Added a backend endpoint (`/api/search/suggestions`) for typeahead search suggestions.
    *   Frontend header now displays these suggestions, debounces API calls, and directly navigates to item pages upon suggestion click.

2.  **Scroll-to-Highlight & URL Cleaning:**
    *   When navigating to views (`Documents`, `Patches`, `Links`, `Misc`) with a `highlight` URL parameter, the page now scrolls to the specified item.
    *   The `highlight` parameter is subsequently removed from the URL for a cleaner address bar, without affecting browser history.
    *   `DataTable.tsx` updated to support `data-item-id` for this feature.

3.  **Admin Breadcrumb Navigation:**
    *   Fixed the "Admin" breadcrumb link in `Breadcrumbs.tsx` to correctly point to `/admin/dashboard` instead of `/admin`.

4.  **Backup Retention Policy:**
    *   Verified and confirmed that the existing backup logic in `app.py` correctly enforces a 30-day retention policy for database backups. The `delete_old_backups` function is called after successful daily backups.

These changes improve search usability, admin navigation, and ensure backup storage is managed efficiently.