### PR TITLE
Add link upload option for Misc category

### DIFF
--- a/app.py
+++ b/app.py
@@ -3252,7 +3252,7 @@ def get_all_misc_files_api():
         sort_order = 'asc'
 
     # Construct Base Query and Parameters for Filtering
-    base_query_select_fields = "mf.id, mf.misc_category_id, mf.user_id, mf.user_provided_title, mf.user_provided_description, mf.original_filename, mf.stored_filename, mf.file_path, mf.file_type, mf.file_size, mf.created_by_user_id, u.username as uploaded_by_username, mf.created_at, mf.updated_by_user_id, upd_u.username as updated_by_username, mf.updated_at, mc.name as category_name, (SELECT COUNT(*) FROM comments c WHERE c.item_id = mf.id AND c.item_type = 'misc_file' AND c.parent_comment_id IS NULL) as comment_count"
+    base_query_select_fields = "mf.id, mf.misc_category_id, mf.user_id, mf.user_provided_title, mf.user_provided_description, mf.original_filename, mf.stored_filename, mf.file_path, mf.file_type, mf.file_size, mf.is_external_link, mf.url, mf.created_by_user_id, u.username as uploaded_by_username, mf.created_at, mf.updated_by_user_id, upd_u.username as updated_by_username, mf.updated_at, mc.name as category_name, (SELECT COUNT(*) FROM comments c WHERE c.item_id = mf.id AND c.item_type = 'misc_file' AND c.parent_comment_id IS NULL) as comment_count"
     base_query_from = "FROM misc_files mf JOIN misc_categories mc ON mf.misc_category_id = mc.id LEFT JOIN users u ON mf.created_by_user_id = u.id LEFT JOIN users upd_u ON mf.updated_by_user_id = upd_u.id" # upd_u for updated_by_username
     
     # params = [] # Replaced by main_query_filter_params
@@ -6058,6 +6058,7 @@ def admin_edit_misc_file(file_id):
     misc_category_id_str = request.form.get('misc_category_id', str(misc_file_item['misc_category_id']))
     user_provided_title = request.form.get('user_provided_title', misc_file_item['user_provided_title'])
     user_provided_description = request.form.get('user_provided_description', misc_file_item['user_provided_description'])
+    url_from_form = request.form.get('url') # New: get URL from form
 
     if not misc_category_id_str: # Category is mandatory
         return jsonify(msg="Misc category ID is required"), 400
@@ -6067,23 +6068,58 @@ def admin_edit_misc_file(file_id):
     except ValueError:
         return jsonify(msg="Invalid misc_category_id format"), 400
 
-    # Initialize with old values, update if new physical file is processed
+    # Initialize with old values, update if new physical file is processed or URL is provided
     new_stored_filename = misc_file_item['stored_filename']
-    new_original_filename = misc_file_item['original_filename'] # In misc_files, original_filename is stored directly
+    new_original_filename = misc_file_item['original_filename']
     new_file_path = misc_file_item['file_path']
     new_file_size = misc_file_item['file_size']
     new_file_type = misc_file_item['file_type']
+    new_is_external_link = misc_file_item['is_external_link']
+    new_url = misc_file_item['url']
     
-    # Path for potentially newly saved file (for cleanup on error)
-    current_file_save_path = None 
+    current_file_save_path = None # Path for potentially newly saved file
 
-    if new_physical_file and new_physical_file.filename != '':
+    action_type_log = 'UPDATE_MISC_FILE_METADATA' # Default action type
+
+    if url_from_form and url_from_form.strip():
+        # User is providing/updating a URL
+        new_url = url_from_form.strip()
+        new_is_external_link = True
+        action_type_log = 'UPDATE_MISC_FILE_URL'
+
+        # If it was previously a file, delete the old physical file
+        if not misc_file_item['is_external_link'] and misc_file_item['stored_filename']:
+            old_physical_file_path = os.path.join(app.config['MISC_UPLOAD_FOLDER'], misc_file_item['stored_filename'])
+            _delete_file_if_exists(old_physical_file_path)
+
+        # Clear file-specific fields
+        new_stored_filename = None
+        new_original_filename = None # Or keep original if desired, for now clear
+        new_file_path = None
+        new_file_size = None
+        new_file_type = None
+
+        if new_physical_file and new_physical_file.filename != '':
+            # User provided both a URL and a file, which is ambiguous. Prioritize URL or return error.
+            # For now, let's assume URL takes precedence if provided, and ignore the file.
+            # Or, return an error:
+            # return jsonify(msg="Cannot provide both a URL and a file. Please choose one."), 400
+            app.logger.warning(f"Misc edit for ID {file_id}: Both URL and file provided. Prioritizing URL.")
+            # The file won't be processed if URL is set.
+
+    elif new_physical_file and new_physical_file.filename != '':
+        # User is uploading/replacing a file
         if not allowed_file(new_physical_file.filename):
             return jsonify(msg="New file type not allowed"), 400
 
-        # Delete old physical file
-        old_physical_file_path = os.path.join(app.config['MISC_UPLOAD_FOLDER'], misc_file_item['stored_filename'])
-        _delete_file_if_exists(old_physical_file_path)
+        action_type_log = 'UPDATE_MISC_FILE_UPLOAD'
+        new_is_external_link = False
+        new_url = None # Clear URL if switching to file
+
+        # Delete old physical file if it existed (and wasn't an external link before)
+        if not misc_file_item['is_external_link'] and misc_file_item['stored_filename']:
+            old_physical_file_path = os.path.join(app.config['MISC_UPLOAD_FOLDER'], misc_file_item['stored_filename'])
+            _delete_file_if_exists(old_physical_file_path)
         
         original_fn = secure_filename(new_physical_file.filename)
         ext = original_fn.rsplit('.', 1)[1].lower() if '.' in original_fn else ''
@@ -6095,63 +6131,65 @@ def admin_edit_misc_file(file_id):
             new_physical_file.save(current_file_save_path)
             new_file_size = os.path.getsize(current_file_save_path)
             new_file_type = new_physical_file.mimetype
-            new_original_filename = original_fn # Update original filename if new file
+            new_original_filename = original_fn
             new_file_path = f"/misc_uploads/{new_stored_filename}"
         except Exception as e:
             app.logger.error(f"Error saving new misc_file physical file during edit: {e}")
+            # Attempt cleanup of partially saved file
+            if current_file_save_path and os.path.exists(current_file_save_path):
+                _delete_file_if_exists(current_file_save_path)
             return jsonify(msg=f"Error saving new physical file: {e}"), 500
-    
-    # Ensure title defaults to original filename if not provided and new file is uploaded
-    # or if title was empty and original filename changed due to new upload.
-    if not user_provided_title and new_original_filename:
-        user_provided_title = new_original_filename
+    # else: No new file and no new URL, just metadata update for existing file/URL.
+    # new_is_external_link and new_url (or file details) remain as they were from misc_file_item.
+
+    if not user_provided_title: # Default title to original filename if title is empty
+        if new_original_filename: # If a file exists (new or old)
+            user_provided_title = new_original_filename
+        elif new_url: # If it's a URL, maybe derive from URL or leave as is if user cleared it
+            # For now, if title is cleared for a URL, it remains cleared.
+            pass
 
 
     try:
         changed_fields = []
-        log_details = {'changed_fields': changed_fields} 
+        log_details = {'changed_fields': changed_fields}
 
+        # Compare with misc_file_item for logging changes
         if misc_category_id != misc_file_item['misc_category_id']:
-            changed_fields.append('misc_category_id')
-            log_details['old_category_id'] = misc_file_item['misc_category_id']
-            log_details['new_category_id'] = misc_category_id
+            changed_fields.append('misc_category_id'); log_details['new_category_id'] = misc_category_id
         if user_provided_title != misc_file_item['user_provided_title']:
-            changed_fields.append('user_provided_title')
-            log_details['old_title'] = misc_file_item['user_provided_title']
-            log_details['new_title'] = user_provided_title
+            changed_fields.append('user_provided_title'); log_details['new_title'] = user_provided_title
         if user_provided_description != misc_file_item['user_provided_description']:
             changed_fields.append('user_provided_description')
-            log_details['description_changed'] = True 
+        if new_url != misc_file_item['url']:
+            changed_fields.append('url'); log_details['new_url'] = new_url
+        if new_is_external_link != misc_file_item['is_external_link']:
+            changed_fields.append('is_external_link'); log_details['is_external_link'] = new_is_external_link
+        if new_original_filename != misc_file_item['original_filename']: # This covers new file upload or clearing
+            changed_fields.append('original_filename'); log_details['new_original_filename'] = new_original_filename
         
-        action_type_log = 'UPDATE_MISC_FILE_METADATA'
-        if new_physical_file and new_physical_file.filename != '': 
-            action_type_log = 'UPDATE_MISC_FILE_UPLOAD' 
-            changed_fields.append('file_content') 
-            log_details['old_original_filename'] = misc_file_item['original_filename']
-            log_details['new_original_filename'] = new_original_filename
-        
-        # Log original filename change even if it's a metadata update but original_filename field changed
-        # This can happen if user_provided_title was empty and new_original_filename became the title
-        if not (new_physical_file and new_physical_file.filename != '') and \
-           new_original_filename != misc_file_item['original_filename']:
-            changed_fields.append('original_filename')
-            log_details['old_original_filename'] = misc_file_item['original_filename']
-            log_details['new_original_filename'] = new_original_filename
+        # Overwrite action_type_log if only metadata changed but type (file/URL) didn't
+        if action_type_log == 'UPDATE_MISC_FILE_UPLOAD' and not (new_physical_file and new_physical_file.filename != ''):
+            action_type_log = 'UPDATE_MISC_FILE_METADATA' # Reverted if no actual file was processed
+        if action_type_log == 'UPDATE_MISC_FILE_URL' and not (url_from_form and url_from_form.strip()):
+             action_type_log = 'UPDATE_MISC_FILE_METADATA'
 
 
         db.execute("""
             UPDATE misc_files
             SET misc_category_id = ?, user_provided_title = ?, user_provided_description = ?,
                 original_filename = ?, stored_filename = ?, file_path = ?,
-                file_type = ?, file_size = ?, updated_by_user_id = ?, updated_at = CURRENT_TIMESTAMP
+                file_type = ?, file_size = ?, is_external_link = ?, url = ?,
+                updated_by_user_id = ?, updated_at = CURRENT_TIMESTAMP
             WHERE id = ?
         """, (misc_category_id, user_provided_title, user_provided_description,
               new_original_filename, new_stored_filename, new_file_path,
-              new_file_type, new_file_size, current_user_id, file_id))
+              new_file_type, new_file_size, new_is_external_link, new_url,
+              current_user_id, file_id))
         
-        if changed_fields: 
+        if changed_fields or action_type_log != 'UPDATE_MISC_FILE_METADATA': # Log if fields changed or type of change implies it
             log_audit_action(
-                action_type=action_type_log,
+                action_type=action_type_log, # This reflects primary change (file upload, URL update, or just metadata)
                 target_table='misc_files',
                 target_id=file_id,
                 details=log_details
@@ -6222,6 +6260,85 @@ def admin_edit_misc_file(file_id):
         if current_file_save_path and os.path.exists(current_file_save_path): 
             _delete_file_if_exists(current_file_save_path)
         return jsonify(msg=f"Server error: {e}"), 500
+
+@app.route('/api/admin/misc_files/add_with_url', methods=['POST'])
+@jwt_required()
+@admin_required
+def admin_add_misc_file_with_url():
+    data = request.get_json()
+    # Ensure 'user_provided_title' from payload is mapped to 'title' for the helper if necessary,
+    # or adjust helper/payload keys. For misc_files, the table has 'user_provided_title'.
+    # The helper's sql_params_tuple uses 'user_provided_title'.
+
+    # _admin_add_item_with_external_link expects certain keys in `data` for `required_fields`
+    # and for populating `form_data` which is then used by `sql_params_tuple`.
+    # Ensure the payload keys match what the helper expects or map them.
+    # For misc_files, the required fields are misc_category_id, user_provided_title, url.
+    # The sql_params_tuple for misc_files (if we adapt one) would be:
+    # ('misc_category_id', 'user_id', 'user_provided_title', 'url', 'user_provided_description',
+    #  'created_by_user_id', 'updated_by_user_id')
+
+    response = _admin_add_item_with_external_link(
+        table_name='misc_files',
+        data=data, # Assumes data contains misc_category_id, user_provided_title, url, user_provided_description
+        required_fields=['misc_category_id', 'user_provided_title', 'url'],
+        sql_insert_query="""INSERT INTO misc_files (misc_category_id, user_id, user_provided_title, url, user_provided_description,
+                                               is_external_link, created_by_user_id, updated_by_user_id)
+                              VALUES (?, ?, ?, ?, ?, TRUE, ?, ?)""", # 8 placeholders
+        sql_params_tuple=(
+            'misc_category_id', 'user_id', 'user_provided_title', 'url', 'user_provided_description',
+            # is_external_link is hardcoded TRUE
+            'created_by_user_id', 'updated_by_user_id' # Handled by helper
+        ) # Tuple has 7 elements if user_id is separate, matches placeholders.
+          # User_id is the user creating it, not a specific user association like in some tables.
+          # For misc_files, user_id is the creator.
+    )
+
+    if response[1] == 201: # Check if creation was successful
+        new_misc_file_data = response[0].get_json()
+        log_audit_action(
+            action_type='CREATE_MISC_FILE_URL', # Differentiate from file upload
+            target_table='misc_files',
+            target_id=new_misc_file_data.get('id'),
+            details={
+                'title': new_misc_file_data.get('user_provided_title'),
+                'url': new_misc_file_data.get('url'),
+                'category_id': new_misc_file_data.get('misc_category_id')
+            }
+        )
+        # --- Notification Logic for admin_add_misc_file_with_url ---
+        if new_misc_file_data and new_misc_file_data.get('id'):
+            try:
+                acting_user_id = int(get_jwt_identity())
+                acting_user_details = find_user_by_id(acting_user_id)
+                actor_username = acting_user_details['username'] if acting_user_details else "System"
+
+                content_type = 'misc' # For watch preferences
+                category = None # Misc items generally don't have sub-categories for watching like documents
+                item_id = new_misc_file_data.get('id')
+
+                # Determine display name for notification
+                display_name = new_misc_file_data.get('user_provided_title', new_misc_file_data.get('original_filename', 'N/A'))
+
+                watchers = database.get_watching_users(get_db(), content_type, category) # Category is None for misc
+                app.logger.info(f"Watchers for {content_type} (Misc URL Add): {len(watchers)} users.")
+                for watcher in watchers:
+                    notification_message = f"New miscellaneous item (URL) '{display_name}' added by {actor_username}."
+                    database.create_notification(
+                        get_db(),
+                        user_id=watcher['id'],
+                        type='new_content_posted',
+                        message=notification_message,
+                        item_id=item_id,
+                        item_type='misc_file', # The item_type in notifications table
+                        content_type=content_type, # The content_type for watch preferences
+                        category=category # None for misc
+                    )
+                if watchers:
+                    get_db().commit()
+            except Exception as e_notify:
+                app.logger.error(f"Error creating notifications for new misc file (URL) ID {new_misc_file_data.get('id')}: {e_notify}")
+    return response
 
 @app.route('/api/admin/misc_files/<int:file_id>/delete', methods=['DELETE'])
 @jwt_required()

--- a/frontend/src/components/admin/AdminUploadToMiscForm.tsx
+++ b/frontend/src/components/admin/AdminUploadToMiscForm.tsx
@@ -25,7 +25,8 @@ interface AdminUploadToMiscFormProps {
 // Form data interface
 interface MiscUploadFormData {
   selectedCategoryId: string;
-  selectedFile?: File | null | undefined; // Can be File, null (cleared), or undefined (initial)
+  selectedFile?: File | null | undefined;
+  url?: string; // Added for URL input
   title?: string;
   description?: string;
 }
@@ -34,10 +35,16 @@ interface MiscUploadFormData {
 const miscUploadValidationSchema = yup.object().shape({
   selectedCategoryId: yup.string().required("Please select a misc category."),
   selectedFile: yup.mixed()
-    .when('$isEditMode', { // Context variable $isEditMode
-      is: (isEditMode: boolean) => !isEditMode, // If NOT in edit mode (i.e., add mode)
-      then: schema => schema.required("Please select a file to upload.").test('filePresent', "File is required for upload.", value => !!value),
-      otherwise: schema => schema.nullable(), // Optional in edit mode
+    .when(['$isEditMode', '$uploadType'], {
+      is: (isEditMode: boolean, uploadType: 'file' | 'url') => !isEditMode && uploadType === 'file',
+      then: schema => schema.required("File is required for upload.").test('filePresent', "File is required.", value => !!value),
+      otherwise: schema => schema.nullable(),
+    }),
+  url: yup.string().url("Must be a valid URL (e.g., http://example.com)")
+    .when(['$isEditMode', '$uploadType'], {
+      is: (isEditMode: boolean, uploadType: 'file' | 'url') => uploadType === 'url' && !isEditMode, // Required if new and type is URL
+      then: schema => schema.required("URL is required when upload type is URL."),
+      otherwise: schema => schema.optional().nullable(),
     }),
   title: yup.string().transform(value => value === '' ? undefined : value).optional().max(255, "Title cannot exceed 255 characters.").nullable(),
   description: yup.string().transform(value => value === '' ? undefined : value).optional().max(1000, "Description cannot exceed 1000 characters.").nullable(),
@@ -52,34 +59,38 @@ const AdminUploadToMiscForm: React.FC<AdminUploadToMiscFormProps> = ({
   onCancelEdit,
 }) => {
   const isEditMode = !!fileToEdit;
+  const [uploadType, setUploadType] = useState<'file' | 'url'>(isEditMode && fileToEdit?.is_external_link ? 'url' : 'file');
 
-  const { register, handleSubmit, formState: { errors }, watch, setValue, reset } = useForm<MiscUploadFormData>({
+  const { register, handleSubmit, formState: { errors }, watch, setValue, reset, trigger } = useForm<MiscUploadFormData>({
     resolver: yupResolver(miscUploadValidationSchema),
-    context: { // Pass context to yup schema
-        isEditMode: isEditMode, 
+    context: {
+        isEditMode: isEditMode,
+        uploadType: uploadType, // Pass uploadType to context
     },
     defaultValues: {
       selectedCategoryId: preselectedCategoryId?.toString() || '',
       title: '',
       description: '',
       selectedFile: null,
+      url: '',
     }
   });
   
   const [miscCategories, setMiscCategories] = useState<MiscCategory[]>([]);
-  const [existingFileName, setExistingFileName] = useState<string | null>(null); // Still needed for display logic
+  const [existingFileName, setExistingFileName] = useState<string | null>(null);
+  const [existingUrl, setExistingUrl] = useState<string | null>(null); // Added for existing URL display
 
   const [isLoading, setIsLoading] = useState(false);
   const [isFetchingCategories, setIsFetchingCategories] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState<number>(0); // For chunked upload progress
-  const [isUploading, setIsUploading] = useState<boolean>(false); // For beforeunload warning
-  // error and successMessage states removed
+  const [uploadProgress, setUploadProgress] = useState<number>(0);
+  const [isUploading, setIsUploading] = useState<boolean>(false);
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { isAuthenticated, user } = useAuth();
-const role = user?.role; // Access role safely, as user can be null
+  const role = user?.role;
   const watchedSelectedFile = watch('selectedFile');
-  const [isDraggingOver, setIsDraggingOver] = useState(false); // Added for drag-drop UI
+  const watchedUrl = watch('url'); // Watch URL field
+  const [isDraggingOver, setIsDraggingOver] = useState(false);
 
   useEffect(() => {
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -88,135 +99,200 @@ const role = user?.role; // Access role safely, as user can be null
         event.returnValue = '';
       }
     };
-
     window.addEventListener('beforeunload', handleBeforeUnload);
-
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
-    };
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, [isUploading]);
 
-  // Effect to warn user if they change tabs during upload
   useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'hidden' && isUploading) {
         showWarningToast('Changing tabs or minimizing the window might interrupt the upload process.');
       }
     };
-
     document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [isUploading]);
 
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [isUploading]); // Dependency array includes isUploading
-
-  // Fetch categories for the dropdown
   useEffect(() => {
     if (isAuthenticated && (role === 'admin' || role === 'super_admin')) {
       setIsFetchingCategories(true);
       fetchMiscCategories()
         .then(setMiscCategories)
-        .catch(() => showErrorToast('Failed to load misc categories.')) // Standardized
+        .catch(() => showErrorToast('Failed to load misc categories.'))
         .finally(() => setIsFetchingCategories(false));
     }
   }, [isAuthenticated, role]);
 
-  // Pre-fill form for edit mode or set preselected category for add mode
   useEffect(() => {
     if (isEditMode && fileToEdit) {
+      const currentUploadType = fileToEdit.is_external_link && fileToEdit.url ? 'url' : 'file';
+      setUploadType(currentUploadType);
       reset({
         selectedCategoryId: fileToEdit.misc_category_id.toString(),
         title: fileToEdit.user_provided_title || '',
         description: fileToEdit.user_provided_description || '',
-        selectedFile: null, // File input reset separately
+        selectedFile: null,
+        url: currentUploadType === 'url' ? fileToEdit.url || '' : '',
       });
-      setExistingFileName(fileToEdit.original_filename);
+      setExistingFileName(currentUploadType === 'file' ? fileToEdit.original_filename : null);
+      setExistingUrl(currentUploadType === 'url' ? fileToEdit.url : null);
       if (fileInputRef.current) fileInputRef.current.value = "";
     } else {
       reset({
-        selectedCategoryId: preselectedCategoryId?.toString() || '',
+        selectedCategoryId: preselectedCategoryId?.toString() || (miscCategories.length > 0 ? miscCategories[0].id.toString() : ''),
         title: '',
         description: '',
         selectedFile: null,
+        url: '',
       });
+      setUploadType('file'); // Default for new
       setExistingFileName(null);
+      setExistingUrl(null);
       if (fileInputRef.current) fileInputRef.current.value = "";
     }
-  }, [isEditMode, fileToEdit, preselectedCategoryId, reset]);
+  }, [isEditMode, fileToEdit, preselectedCategoryId, reset, miscCategories]);
 
+  // Re-validate when uploadType changes
+  useEffect(() => {
+    trigger(); // Trigger validation for all fields based on new context
+  }, [uploadType, trigger]);
+
+  const handleUploadTypeChange = (newType: 'file' | 'url') => {
+    setUploadType(newType);
+    if (newType === 'url') {
+      setValue('selectedFile', null); // Clear file if switching to URL
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      setExistingFileName(null); // Clear displayed existing file name
+    } else {
+      setValue('url', ''); // Clear URL if switching to file
+      setExistingUrl(null); // Clear displayed existing URL
+    }
+    // Trigger validation after state update and value changes
+    setTimeout(() => trigger(), 0);
+  };
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files && event.target.files[0]) {
       setValue('selectedFile', event.target.files[0], { shouldValidate: true, shouldDirty: true });
-      if (isEditMode) setExistingFileName(null); 
+      setValue('url', '', { shouldDirty: true }); // Clear URL if file is chosen
+      setExistingFileName(null); // No longer showing existing file name if new one is staged
+      setExistingUrl(null);
     } else {
       setValue('selectedFile', null, { shouldValidate: true, shouldDirty: true });
     }
   };
 
+  const handleUrlInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      setValue('url', event.target.value, { shouldValidate: true, shouldDirty: true });
+      setValue('selectedFile', null, { shouldDirty: true }); // Clear file if URL is being typed
+      if (fileInputRef.current) fileInputRef.current.value = "";
+      setExistingFileName(null);
+      setExistingUrl(null);
+  };
+
   const clearFileSelection = () => {
     setValue('selectedFile', null, { shouldValidate: true, shouldDirty: true });
     if (fileInputRef.current) fileInputRef.current.value = "";
-    if (isEditMode && fileToEdit) {
-      setExistingFileName(fileToEdit.original_filename);
+    if (isEditMode && fileToEdit && !fileToEdit.is_external_link) {
+      setExistingFileName(fileToEdit.original_filename); // Restore display of current file if editing
+    }
+  };
+
+  const clearUrlInput = () => {
+    setValue('url', '', { shouldValidate: true, shouldDirty: true });
+    if (isEditMode && fileToEdit && fileToEdit.is_external_link) {
+        setExistingUrl(fileToEdit.url); // Restore display of current URL if editing
     }
   };
 
   const onSubmit: SubmitHandler<MiscUploadFormData> = async (data) => {
     if (!isAuthenticated || !role || !['admin', 'super_admin'].includes(role)) {
-      showErrorToast('Not authorized.'); // Standardized
+      showErrorToast('Not authorized.');
       return;
     }
+
+    // Additional validation based on uploadType
+    if (uploadType === 'file' && !data.selectedFile && !isEditMode) {
+      showErrorToast('Please select a file for new uploads.');
+      return;
+    }
+    if (uploadType === 'file' && !data.selectedFile && isEditMode && !fileToEdit?.stored_filename && !fileToEdit?.is_external_link) {
+      // If editing, and it was a file, and user clears selection, it implies metadata update or error.
+      // If it's intended to be a file and user clears it, it's an issue unless switching to URL.
+      // This case is tricky: if it's a file, and user clears it, it should only be a metadata update.
+      // The backend `editAdminMiscFile` handles formData: if `file` is not present, it doesn't replace.
+    }
+    if (uploadType === 'url' && (!data.url || !data.url.trim())) {
+      showErrorToast('Please enter a valid URL.');
+      return;
+    }
+
     setIsLoading(true);
-    if (data.selectedFile) {
+    if (uploadType === 'file' && data.selectedFile) {
       setIsUploading(true);
     }
-    setUploadProgress(0); // Reset progress
+    setUploadProgress(0);
 
     try {
       let resultFile: MiscFile;
 
-      if (data.selectedFile) { // New file upload or replacing an existing file
-        const metadata = {
-          misc_category_id: data.selectedCategoryId,
-          user_provided_title: data.title?.trim() || '', // Backend handles default to filename
-          user_provided_description: data.description?.trim() || '',
-        };
-
-        resultFile = await uploadFileInChunks(
-          data.selectedFile,
-          'misc_file',
-          metadata,
-          (progress) => setUploadProgress(progress)
-        );
-        // showSuccessToast(`File "${resultFile.original_filename}" uploaded successfully!`); // Removed as per subtask
-        if (onUploadSuccess) onUploadSuccess(resultFile); // Use onUploadSuccess for new/replaced file
-         reset({
-            selectedCategoryId: preselectedCategoryId?.toString() || data.selectedCategoryId,
-            title: '',
-            description: '',
-            selectedFile: null,
-        });
-        if (fileInputRef.current) fileInputRef.current.value = "";
-
-      } else if (isEditMode && fileToEdit) { // Metadata-only update for an existing file
+      if (isEditMode && fileToEdit) { // Editing existing item
         const formDataPayload = new FormData();
         formDataPayload.append('misc_category_id', data.selectedCategoryId);
         formDataPayload.append('user_provided_title', data.title?.trim() || '');
         formDataPayload.append('user_provided_description', data.description?.trim() || '');
-        // No file is appended here for metadata-only update
+
+        if (uploadType === 'file' && data.selectedFile) {
+          formDataPayload.append('file', data.selectedFile);
+          formDataPayload.append('url', ''); // Ensure URL is cleared if submitting a file
+        } else if (uploadType === 'url' && data.url) {
+          formDataPayload.append('url', data.url.trim());
+          // No 'file' part if submitting a URL
+        }
+        // If neither data.selectedFile nor data.url is provided for an edit,
+        // it's a metadata-only update. The backend handles this.
 
         resultFile = await editAdminMiscFile(fileToEdit.id, formDataPayload);
-        // showSuccessToast(`File "${resultFile.user_provided_title || resultFile.original_filename}" metadata updated successfully!`); // Removed as per subtask
-        if (onFileUpdated) onFileUpdated(resultFile); // Use onFileUpdated for metadata changes
+        if (onFileUpdated) onFileUpdated(resultFile);
 
-      } else {
-        // Should not happen if validation is correct (e.g., new file requires selectedFile)
-        showErrorToast("No file selected for new upload.");
-        setIsLoading(false);
-        return;
+      } else { // Adding new item
+        if (uploadType === 'file' && data.selectedFile) {
+          const metadata = {
+            misc_category_id: data.selectedCategoryId,
+            user_provided_title: data.title?.trim() || '',
+            user_provided_description: data.description?.trim() || '',
+          };
+          resultFile = await uploadFileInChunks(data.selectedFile, 'misc_file', metadata, setUploadProgress);
+          if (onUploadSuccess) onUploadSuccess(resultFile);
+        } else if (uploadType === 'url' && data.url) {
+          const payload = {
+            misc_category_id: parseInt(data.selectedCategoryId),
+            user_provided_title: data.title?.trim(),
+            url: data.url.trim(),
+            user_provided_description: data.description?.trim(),
+          };
+          resultFile = await addAdminMiscFileWithUrl(payload);
+          if (onUploadSuccess) onUploadSuccess(resultFile);
+        } else {
+          // Should be caught by earlier validation
+          throw new Error("Invalid state for submission.");
+        }
       }
+
+      // Reset form after successful submission only if NOT in edit mode
+      if (!isEditMode) {
+        reset({
+            selectedCategoryId: preselectedCategoryId?.toString() || (miscCategories.length > 0 ? miscCategories[0].id.toString() : ''),
+            title: '',
+            description: '',
+            selectedFile: null,
+            url: '',
+        });
+        setUploadType('file'); // Reset to default upload type
+        if (fileInputRef.current) fileInputRef.current.value = "";
+      }
+      setUploadProgress(0); // Reset progress
+
     } catch (err: any) {
       const backendMessage = err.response?.data?.msg || err.message;
       let userMessage = "File operation failed.";
@@ -227,18 +303,25 @@ const role = user?.role; // Access role safely, as user can be null
         userMessage = backendMessage;
       }
       showErrorToast(userMessage);
-      // Future: Add checks for other constraint errors here
-      if (data.selectedFile) setIsUploading(false);
+      if (uploadType === 'file' && data.selectedFile) setIsUploading(false);
     } finally {
       setIsLoading(false);
-      if (data.selectedFile) setIsUploading(false); // Ensure isUploading is reset
-      // Consider resetting uploadProgress after a delay or based on success/failure
+      if (uploadType === 'file' && data.selectedFile) setIsUploading(false);
     }
   };
   
   const onFormError = (formErrors: FieldErrors<MiscUploadFormData>) => {
     console.error("Form validation errors:", formErrors);
-    showErrorToast("Please correct the errors highlighted in the form."); // Standardized
+    // Consolidate error messages for toast
+    let errorMessages = "Please correct the highlighted errors: ";
+    const messages: string[] = [];
+    if (formErrors.selectedCategoryId) messages.push(formErrors.selectedCategoryId.message || "Category error");
+    if (uploadType === 'file' && formErrors.selectedFile) messages.push(formErrors.selectedFile.message || "File error");
+    if (uploadType === 'url' && formErrors.url) messages.push(formErrors.url.message || "URL error");
+    if (formErrors.title) messages.push(formErrors.title.message || "Title error");
+    if (formErrors.description) messages.push(formErrors.description.message || "Description error");
+
+    showErrorToast(errorMessages + messages.join('; '));
   };
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
@@ -282,22 +365,20 @@ const role = user?.role; // Access role safely, as user can be null
     <form onSubmit={handleSubmit(onSubmit, onFormError)} className="space-y-6 bg-white dark:bg-gray-800 dark:border-gray-700 p-6 rounded-lg shadow-lg border border-gray-200">
       <div className="flex justify-between items-center">
         <h3 className="text-xl font-semibold text-gray-800 dark:text-gray-100">
-          {isEditMode ? 'Edit Miscellaneous File' : 'Upload File to Misc Category'}
+          {isEditMode ? 'Edit Miscellaneous Item' : 'Add Miscellaneous Item'}
         </h3>
         {isEditMode && onCancelEdit && (
-                  <button
-                    type="button"
-                    onClick={onCancelEdit}
-                    disabled={isLoading}
-                    // This className string is the correct one for the small, styled button.
-                    className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-                  >
-                    <MinusCircle size={18} className="mr-2" />
-                    Cancel Edit
-                  </button>
-                )}
+          <button
+            type="button"
+            onClick={onCancelEdit}
+            disabled={isLoading}
+            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
+          >
+            <MinusCircle size={18} className="mr-2" />
+            Cancel Edit
+          </button>
+        )}
       </div>
-      {/* Global error/success messages removed */}
 
       <div>
         <label htmlFor="selectedCategoryId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Misc Category*</label>
@@ -317,66 +398,127 @@ const role = user?.role; // Access role safely, as user can be null
         {errors.selectedCategoryId && <p className="mt-1 text-sm text-red-600">{errors.selectedCategoryId.message}</p>}
       </div>
 
-      <div>
-        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-          {isEditMode ? 'Replace File (Optional)' : 'Select File*'}
-        </label>
-        <div
-          className={`mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md dark:border-gray-600 ${isDraggingOver ? 'border-blue-500 bg-blue-50 dark:bg-gray-700' : 'hover:border-blue-500 dark:hover:border-blue-400'} transition-colors`}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-        >
-          <div className="space-y-1 text-center">
-            <UploadCloud className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
-            <div className="flex text-sm text-gray-600 dark:text-gray-400">
-              <label htmlFor="selectedFile" className="relative cursor-pointer bg-white dark:bg-gray-800 rounded-md font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300 focus-within:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
-                <span>{watchedSelectedFile ? 'Change file' : 'Upload a file'}</span>
-                <input 
-                    id="selectedFile" // id should match RHF field name if possible or be unique
-                    name="selectedFile-input" // actual input name
-                    type="file" 
-                    className="sr-only"
-                    onChange={handleFileChange} // RHF setValue is called here
-                    ref={fileInputRef} 
-                    disabled={isLoading} 
-                />
-              </label>
-              <p className="pl-1">or drag and drop</p>
-            </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400">Any allowed file type.</p>
-          </div>
+      {/* Upload Type Selection */}
+      <div className="mt-4">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Upload Type</label>
+        <div className="mt-2 flex space-x-4">
+          {(['file', 'url'] as const).map((type) => (
+            <label key={type} className="inline-flex items-center">
+              <input
+                type="radio"
+                className="form-radio h-4 w-4 text-blue-600 border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:focus:ring-blue-500"
+                name="uploadType"
+                value={type}
+                checked={uploadType === type}
+                onChange={() => handleUploadTypeChange(type)}
+                disabled={isLoading}
+              />
+              <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
+                {type === 'file' ? 'Upload File' : 'Provide URL'}
+              </span>
+            </label>
+          ))}
         </div>
-        {(watchedSelectedFile || (isEditMode && existingFileName)) && (
-          <div className="mt-3 flex items-center justify-between p-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md">
-            <div className='flex items-center space-x-2 overflow-hidden'>
-              {watchedSelectedFile ? (
-                <CheckCircle2 size={18} className="text-green-500 flex-shrink-0" />
-              ) : (
-                <FileIconLucide size={18} className="text-gray-500 dark:text-gray-400 flex-shrink-0" />
-              )}
-               <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
-                 {watchedSelectedFile ? (watchedSelectedFile as File).name : existingFileName}
-               </span>
-               {isEditMode && existingFileName && !watchedSelectedFile && <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">(current file)</span>}
+      </div>
+
+      {/* Conditional File Upload Input */}
+      {uploadType === 'file' && (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+            {isEditMode && fileToEdit && !fileToEdit.is_external_link ? 'Replace File (Optional)' : 'Select File*'}
+          </label>
+          <div
+            className={`mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-gray-300 border-dashed rounded-md dark:border-gray-600 ${isDraggingOver ? 'border-blue-500 bg-blue-50 dark:bg-gray-700' : 'hover:border-blue-500 dark:hover:border-blue-400'} transition-colors`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            <div className="space-y-1 text-center">
+              <UploadCloud className="mx-auto h-12 w-12 text-gray-400 dark:text-gray-500" />
+              <div className="flex text-sm text-gray-600 dark:text-gray-400">
+                <label htmlFor="selectedFile" className="relative cursor-pointer bg-white dark:bg-gray-800 rounded-md font-medium text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300 focus-within:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                  <span>{watchedSelectedFile ? 'Change file' : 'Upload a file'}</span>
+                  <input
+                      id="selectedFile"
+                      name="selectedFile-input"
+                      type="file"
+                      className="sr-only"
+                      onChange={handleFileChange}
+                      ref={fileInputRef}
+                      disabled={isLoading}
+                  />
+                </label>
+                <p className="pl-1">or drag and drop</p>
+              </div>
+              <p className="text-xs text-gray-500 dark:text-gray-400">Any allowed file type.</p>
             </div>
-            {watchedSelectedFile && (
-                <button type="button" onClick={clearFileSelection} disabled={isLoading} className="p-1 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-200 dark:text-gray-500 dark:hover:text-gray-300 dark:hover:bg-gray-600">
+          </div>
+          {(watchedSelectedFile || (isEditMode && existingFileName)) && (
+            <div className="mt-3 flex items-center justify-between p-2 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md">
+              <div className='flex items-center space-x-2 overflow-hidden'>
+                {watchedSelectedFile ? (
+                  <CheckCircle2 size={18} className="text-green-500 flex-shrink-0" />
+                ) : (
+                  <FileIconLucide size={18} className="text-gray-500 dark:text-gray-400 flex-shrink-0" />
+                )}
+                 <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+                   {watchedSelectedFile ? (watchedSelectedFile as File).name : existingFileName}
+                 </span>
+                 {isEditMode && existingFileName && !watchedSelectedFile && <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">(current file)</span>}
+              </div>
+              {watchedSelectedFile && (
+                  <button type="button" onClick={clearFileSelection} disabled={isLoading} className="p-1 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-200 dark:text-gray-500 dark:hover:text-gray-300 dark:hover:bg-gray-600">
+                      <X size={16} />
+                  </button>
+              )}
+            </div>
+          )}
+          {errors.selectedFile && <p className="mt-1 text-sm text-red-600">{errors.selectedFile.message}</p>}
+        </div>
+      )}
+
+      {/* Conditional URL Input */}
+      {uploadType === 'url' && (
+        <div>
+          <label htmlFor="url" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            URL*
+          </label>
+          <div className="mt-1 relative rounded-md shadow-sm">
+            <input
+              type="text"
+              id="url"
+              {...register("url")}
+              placeholder="e.g., https://example.com/file.pdf"
+              disabled={isLoading}
+              onChange={handleUrlInputChange}
+              className={`block w-full pr-10 sm:text-sm border-gray-300 rounded-md p-2 focus:ring-blue-500 focus:border-blue-500 ${errors.url ? 'border-red-500' : ''} dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400`}
+            />
+            {(watchedUrl || (isEditMode && existingUrl)) && (
+                 <button
+                    type="button"
+                    onClick={clearUrlInput}
+                    disabled={isLoading}
+                    className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+                    aria-label="Clear URL"
+                >
                     <X size={16} />
                 </button>
             )}
           </div>
-        )}
-        {errors.selectedFile && <p className="mt-1 text-sm text-red-600">{errors.selectedFile.message}</p>}
-      </div>
+          {isEditMode && existingUrl && !watchedUrl && <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Current URL: {existingUrl}</p>}
+          {errors.url && <p className="mt-1 text-sm text-red-600">{errors.url.message}</p>}
+        </div>
+      )}
 
       <div>
-        <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">File Title (Optional)</label>
+        <label htmlFor="title" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {uploadType === 'file' ? 'File Title (Optional)' : 'Link Title (Optional)'}
+        </label>
         <input 
             type="text" 
             id="title" 
             {...register("title")}
-            placeholder={isEditMode && fileToEdit ? fileToEdit.original_filename : "Defaults to filename if blank"}
+            placeholder={isEditMode && fileToEdit ? (fileToEdit.original_filename || fileToEdit.url) : (uploadType === 'file' ? "Defaults to filename if blank" : "Defaults to URL if blank")}
             disabled={isLoading}
             className={`mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md p-2 focus:ring-blue-500 focus:border-blue-500 ${errors.title ? 'border-red-500' : ''} dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600 dark:placeholder-gray-400`}
         />
@@ -384,7 +526,9 @@ const role = user?.role; // Access role safely, as user can be null
       </div>
 
       <div>
-        <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">File Description (Optional)</label>
+        <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {uploadType === 'file' ? 'File Description (Optional)' : 'Link Description (Optional)'}
+        </label>
         <textarea 
             id="description" 
             rows={3} 
@@ -397,14 +541,14 @@ const role = user?.role; // Access role safely, as user can be null
 
       <div className="flex space-x-3">
         <button type="submit" 
-                disabled={isLoading || isFetchingCategories || (!isEditMode && !watchedSelectedFile) || !watch('selectedCategoryId')}
+                disabled={isLoading || isFetchingCategories || (!isEditMode && ((uploadType === 'file' && !watchedSelectedFile) || (uploadType === 'url' && !watchedUrl))) || !watch('selectedCategoryId')}
                 className="flex-1 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50">
-          {isLoading ? (isEditMode ? 'Updating...' : 'Uploading...') : (isEditMode ? 'Update File Details' : 'Upload to Misc')}
+          {isLoading ? (isEditMode ? 'Updating...' : (uploadType === 'file' ? 'Uploading...' : 'Adding URL...')) : (isEditMode ? 'Update Item' : (uploadType === 'file' ? 'Upload File' : 'Add URL'))}
         </button>
       </div>
 
       {/* Upload Progress Bar */}
-      {isLoading && watchedSelectedFile && uploadProgress > 0 && (
+      {isLoading && uploadType === 'file' && watchedSelectedFile && uploadProgress > 0 && (
         <div className="w-full bg-gray-200 rounded-full h-4 dark:bg-gray-700 my-3 relative">
           <div
             className="bg-blue-600 h-4 rounded-full transition-all duration-150 ease-out"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1939,6 +1939,32 @@ export async function addAdminMiscCategory(categoryData: AddCategoryPayload): Pr
 
 // --- Misc File API Functions ---
 
+// Payload for adding a misc file with URL
+export interface AddMiscFileUrlPayload {
+  misc_category_id: number;
+  user_provided_title?: string; // Optional, backend might default from URL or filename
+  url: string;
+  user_provided_description?: string;
+}
+
+export async function addAdminMiscFileWithUrl(payload: AddMiscFileUrlPayload): Promise<MiscFile> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/admin/misc_files/add_with_url`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...getAuthHeader() },
+      body: JSON.stringify(payload),
+    });
+    return handleApiError(response, 'Failed to add misc file with URL');
+  } catch (error: any) {
+    if (error instanceof TypeError && error.message.toLowerCase().includes('failed to fetch')) {
+      setGlobalOfflineStatus(true);
+      showErrorToast(OFFLINE_MESSAGE);
+    }
+    console.error('Error adding misc file with URL:', error);
+    throw error;
+  }
+}
+
 export async function uploadAdminMiscFile(formData: FormData): Promise<MiscFile> {
   try {
     const response = await fetch(`${API_BASE_URL}/api/admin/misc_files/upload`, {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -244,6 +244,8 @@ export interface MiscFile {
   file_path: string; // Server path, e.g., /misc_uploads/unique_name.ext
   file_type: string | null;
   file_size: number | null;
+  is_external_link?: boolean; // Added
+  url?: string | null; // Added
   created_at?: string; // Assuming backend field is created_at
   updated_at?: string;
   uploaded_by_username?: string;

--- a/frontend/src/views/MiscView.tsx
+++ b/frontend/src/views/MiscView.tsx
@@ -305,16 +305,28 @@ const role = user?.role; // Access role safely, as user can be null
 
   const handleBulkDownloadMiscFiles = async () => {
     if (selectedMiscFileIds.size === 0) { showErrorToast("No items selected."); return; }
+
+    const downloadableFiles = miscFiles.filter(
+      mf => selectedMiscFileIds.has(mf.id) && !mf.is_external_link && mf.is_downloadable !== false
+    );
+
+    if (downloadableFiles.length === 0) {
+      showErrorToast("No downloadable files selected. External links or non-downloadable items cannot be bulk downloaded.");
+      return;
+    }
+    const downloadableFileIds = downloadableFiles.map(df => df.id);
+
     setIsDownloadingSelected(true);
     try {
-      // bulkDownloadItems now returns Promise<void> and handles the download triggering and filename generation.
-      await bulkDownloadItems(Array.from(selectedMiscFileIds), 'misc_file');
-      // The API service (and worker) will handle their own toasts for lower-level success/error.
-      // This view can show a general success message.
-      showSuccessToast('Bulk download initiated for selected miscellaneous files.');
+      await bulkDownloadItems(downloadableFileIds, 'misc_file');
+      if (downloadableFileIds.length === selectedMiscFileIds.size) {
+        showSuccessToast('Bulk download initiated for all selected miscellaneous files.');
+      } else {
+        showSuccessToast(`Bulk download initiated for ${downloadableFileIds.length} file(s). External links or non-downloadable items were excluded.`);
+      }
     } catch (e: any) {
       console.error("MiscView: Bulk download error:", e);
-      // showErrorToast is likely called within bulkDownloadItems on error.
+      // Error toast likely handled by bulkDownloadItems or its worker
     } finally {
       setIsDownloadingSelected(false);
     }
@@ -370,10 +382,26 @@ const role = user?.role; // Access role safely, as user can be null
     // Assuming there's an updated_at field that might be added later or is implicitly handled by a similar pattern.
     // For now, only created_at is explicitly in the provided column defs.
     { 
-      key: 'file_path', 
+      key: 'file_path', // Keep key as file_path for sorting if backend sorts on this, or change if sorting by URL
       header: 'Link', 
       render: (f: MiscFile) => {
         const isEffectivelyDownloadable = f.is_downloadable !== false; // Default to true if undefined
+
+        if (f.is_external_link && f.url) {
+          return (
+            <a
+              href={f.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center text-blue-600 hover:text-blue-800"
+              onClick={(e) => e.stopPropagation()}
+              title="Open external link"
+            >
+              <ExternalLink size={14} className="mr-1"/>Open Link
+            </a>
+          );
+        }
+        // Logic for uploaded files (including playable video check)
         if (!isEffectivelyDownloadable) {
           return (
             <span className="flex items-center text-gray-400 cursor-not-allowed" title="Download not permitted">
@@ -381,14 +409,13 @@ const role = user?.role; // Access role safely, as user can be null
             </span>
           );
         }
-        // If it's a playable video, show Play button, otherwise just Download
         if (isPlayableVideo(f.file_type)) {
           return (
             <div className="flex items-center space-x-2">
               <button
                 onClick={(e) => {
                   e.stopPropagation();
-                  setVideoModalUrl(`${API_BASE_URL}${f.file_path}`);
+                  setVideoModalUrl(`${API_BASE_URL}${f.file_path}`); // file_path for uploaded videos
                   setVideoModalTitle(f.user_provided_title || f.original_filename);
                   setVideoModalFileType(f.file_type);
                   setShowVideoModal(true);
@@ -411,7 +438,7 @@ const role = user?.role; // Access role safely, as user can be null
               </a>
             </div>
           );
-        } else {
+        } else if (f.file_path) { // Ensure file_path exists for uploaded files
           return (
             <a 
               href={`${API_BASE_URL}${f.file_path}`} 
@@ -425,6 +452,8 @@ const role = user?.role; // Access role safely, as user can be null
             </a>
           );
         }
+        // Fallback if no URL and no file_path (should ideally not happen for valid entries)
+        return <span className="text-gray-400 italic">No link/file</span>;
       }
     },
     { 

--- a/schema.sql
+++ b/schema.sql
@@ -231,6 +231,8 @@ CREATE TABLE IF NOT EXISTS misc_files (
     file_path TEXT NOT NULL,
     file_type TEXT,
     file_size INTEGER,
+    is_external_link BOOLEAN DEFAULT FALSE, -- True if this is an external URL
+    url TEXT, -- URL if it's an external link
     created_by_user_id INTEGER NOT NULL,
     created_at TIMESTAMP DEFAULT (strftime('%Y-%m-%d %H:%M:%S', 'now', '+05:30')),
     updated_by_user_id INTEGER,


### PR DESCRIPTION
This change introduces the ability to add miscellaneous items as external URLs in addition to file uploads.

Key changes:
- Backend: Added a new route for adding misc items via URL and updated the edit route to handle switching between file and URL types. The GET API for misc files now includes URL-related fields.
- Database: Added `is_external_link` and `url` columns to the `misc_files` table.
- Frontend: Updated the `MiscFile` type, relevant API services, the admin form for misc items to support both file and URL inputs, and the misc view to correctly display and handle both types, including adjustments to bulk download.